### PR TITLE
Fix compatibility with the rails core acts_as_tree plugin/gem

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -83,7 +83,7 @@ class << ActiveRecord::Base
   end
   
   # Alias has_ancestry with acts_as_tree, if it's available.
-  if !respond_to?(:acts_as_tree)
+  if !defined?(ActsAsTree) 
     alias_method :acts_as_tree, :has_ancestry
   end
 end


### PR DESCRIPTION
This fixes Issue #39, but only for tree plugins that defines the ActsAsTree module.
