### PR TITLE
Always use table and primary key to specify conditions

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -70,7 +70,7 @@ module Ancestry
     end
 
     def ancestor_conditions
-      {self.base_class.primary_key => ancestor_ids}
+      {primary_key_with_table => ancestor_ids}
     end
 
     def ancestors depth_options = {}
@@ -82,7 +82,7 @@ module Ancestry
     end
 
     def path_conditions
-      {self.base_class.primary_key => path_ids}
+      {primary_key_with_table => path_ids}
     end
 
     def path depth_options = {}
@@ -150,7 +150,7 @@ module Ancestry
 
     # Siblings
     def sibling_conditions
-      {self.base_class.ancestry_column => read_attribute(self.base_class.ancestry_column)}
+      {primary_key_with_table => read_attribute(self.base_class.ancestry_column)}
     end
 
     def siblings
@@ -184,7 +184,7 @@ module Ancestry
 
     # Subtree
     def subtree_conditions
-      ["#{self.base_class.table_name}.#{self.base_class.primary_key} = ? or #{self.base_class.table_name}.#{self.base_class.ancestry_column} like ? or #{self.base_class.table_name}.#{self.base_class.ancestry_column} = ?", self.id, "#{child_ancestry}/%", child_ancestry]
+      ["#{primary_key_with_table} = ? or #{self.base_class.table_name}.#{self.base_class.ancestry_column} like ? or #{self.base_class.table_name}.#{self.base_class.ancestry_column} = ?", self.id, "#{child_ancestry}/%", child_ancestry]
     end
 
     def subtree depth_options = {}
@@ -223,6 +223,10 @@ module Ancestry
       else
         key.to_i
       end
+    end
+
+    def primary_key_with_table
+      "#{self.base_class.table_name}.#{self.base_class.primary_key}"
     end
 
     def primary_key_type


### PR DESCRIPTION
Hey there,

I'm using the `*_conditions` methods to construct queries for another model.  `#subtree_conditions` is the only method that works fine because it uses `#{table_name}.#{primary_key}`. This is a single commit to fix the other methods.

I could not run your tests because of `uninitialized constant Test::Unit::AutoRunner::Priority (NameError)`. I was too lazy to look into it, but I don't think that I broke anything ;-)
