### PR TITLE
Correctly set the ancestry column when creating a child within an after_* callback

### DIFF
--- a/test/has_ancestry_test.rb
+++ b/test/has_ancestry_test.rb
@@ -448,7 +448,6 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
-  # NOTE: A workaround for this case is to call self.reload before calling self.children in the after_create
   def test_node_creation_in_after_create
     AncestryTestDatabase.with_model do |model|
       children=[]


### PR DESCRIPTION
I noticed an issue where creating a child record with the ancestry field set to just the parent id, rather than the entire parent path.

I have added a test reproducing the behaviour, and a fix to the code.

The main issue looked to be that the child_ancestry method was using the ancestry path before the save (using _was) which for new records was obviously blank.

This revision uses the current value of the parent's ancestry path, and adds a child_ancestry_was method to return the old behaviour (with a more descriptive name).

The change to update_descendants_with_new_ancestry was due to it relying on the old behaviour. The revised version explicitly replaces the old parent ancestry snippet (using child_ancestry_was) with the new path.

Please let me know if you need any additional information, or if you would like me to revise the patch.