### PR TITLE
Added a before_save callback for cache_depth

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -68,6 +68,7 @@ class << ActiveRecord::Base
 
       # Cache depth in depth cache column before save
       before_validation :cache_depth
+      before_save :cache_depth
 
       # Validate depth column
       validates_numericality_of depth_cache_column, :greater_than_or_equal_to => 0, :only_integer => true, :allow_nil => false

--- a/test/has_ancestry_test.rb
+++ b/test/has_ancestry_test.rb
@@ -472,6 +472,17 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_depth_caching_after_subtree_movement
+    AncestryTestDatabase.with_model :depth => 6, :width => 1, :cache_depth => true, :depth_cache_column => :depth_cache do |model, roots|
+      node = model.at_depth(3).first
+      node.update_attributes(:parent => model.roots.first)
+      assert_equal(1, node.depth_cache)
+      node.descendants.each do |descendant|
+        assert_equal(descendant.depth, descendant.depth_cache)
+      end
+    end
+  end
+
   def test_depth_scopes
     AncestryTestDatabase.with_model :depth => 4, :width => 2, :cache_depth => true do |model, roots|
       model.before_depth(2).all? { |node| assert node.depth < 2 }


### PR DESCRIPTION
Hey there, here's my attempt at addressing issue #64.

Added a before_save callback for cache_depth as well as the existing before_validation callback. This ensures that all descendants in a subtree have their depth cache updated when the subtree is moved.
