### PR TITLE
Add parent query methods

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -122,6 +122,10 @@ module Ancestry
       if parent_id.blank? then nil else unscoped_find(parent_id) end
     end
 
+    def parent?
+      parent_id.present?
+    end
+
     # Root
     def root_id
       if ancestor_ids.empty? then id else ancestor_ids.first end

--- a/test/has_ancestry_test.rb
+++ b/test/has_ancestry_test.rb
@@ -107,6 +107,7 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
         # Parent assertions
         assert_equal nil, lvl0_node.parent_id
         assert_equal nil, lvl0_node.parent
+        assert !lvl0_node.parent?
         # Root assertions
         assert_equal lvl0_node.id, lvl0_node.root_id
         assert_equal lvl0_node, lvl0_node.root
@@ -139,6 +140,7 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
           # Parent assertions
           assert_equal lvl0_node.id, lvl1_node.parent_id
           assert_equal lvl0_node, lvl1_node.parent
+          assert lvl1_node.parent?
           # Root assertions
           assert_equal lvl0_node.id, lvl1_node.root_id
           assert_equal lvl0_node, lvl1_node.root
@@ -171,6 +173,7 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
             # Parent assertions
             assert_equal lvl1_node.id, lvl2_node.parent_id
             assert_equal lvl1_node, lvl2_node.parent
+            assert lvl2_node.parent?
             # Root assertions
             assert_equal lvl0_node.id, lvl2_node.root_id
             assert_equal lvl0_node, lvl2_node.root


### PR DESCRIPTION
While adding ancestry to some STI classes I found myself wanting to add a validation to restrict non-leaf nodes:

``` ruby
class Leaf < ActiveRecord::Base
  has_ancestry

  validate :parent_is_leaf_group, if: :parent?

  def parent_is_leaf_group
    errors.add :parent, "is not leaf group" unless parent.is_a? LeafGroup
  end
end

class LeafGroup < Leaf
  # Things Leaf can't have...
end
```

Sadly, my friend the [query attribute method](https://github.com/rails/rails/blob/3d55957c3d024e592f847b1128e939038f3588a7/activerecord/lib/active_record/attribute_methods/query.rb) (`parent?`) wasn't available—so I added it. It adds greater semantic value than `if: :parent_id` in situations like this, while being more efficient than `if: :parent`.

Tests were added also, but one test on master was already failing.
