### PR TITLE
Added the ability to set the ancestry column delimiter

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,5 +4,5 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'ancestry/exceptions
 require File.join(File.expand_path(File.dirname(__FILE__)), 'ancestry/has_ancestry')
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+
 end

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -26,6 +26,20 @@ module Ancestry
         raise Ancestry::AncestryException.new("Invalid orphan strategy, valid ones are :rootify,:adopt, :restrict and :destroy.")
       end
     end
+
+    # Delimiter writer
+    def ancestry_delimiter= ancestry_delimiter
+      # Check value of the delimiter. Restrict if it's numeric.
+      if ancestry_delimiter =~ /^\D+$/
+        class_variable_set :@@ancestry_delimiter, ancestry_delimiter
+      else
+        raise Ancestry::AncestryException.new("Invalid delimiter, only non-numeric characters are allowed.")
+      end
+    end
+
+    def ancestry_pattern
+      /\A[0-9]+(#{Regexp.escape(ancestry_delimiter)}[0-9]+)*\Z/
+    end
     
     # Arrangement
     def arrange options = {}
@@ -137,7 +151,7 @@ module Ancestry
             # ... rebuild ancestry from parents array
             ancestry, parent = nil, parents[node.id]
             until parent.nil?
-              ancestry, parent = if ancestry.nil? then parent else "#{parent}/#{ancestry}" end, parents[parent]
+              ancestry, parent = if ancestry.nil? then parent else "#{parent}#{self.ancestry_delimiter}#{ancestry}" end, parents[parent]
             end
             node.without_ancestry_callbacks do
               node.update_attribute node.ancestry_column, ancestry
@@ -154,7 +168,7 @@ module Ancestry
           node.without_ancestry_callbacks do
             node.update_attribute ancestry_column, ancestry
           end
-          build_ancestry_from_parent_ids! node.id, if ancestry.nil? then "#{node.id}" else "#{ancestry}/#{node.id}" end
+          build_ancestry_from_parent_ids! node.id, if ancestry.nil? then "#{node.id}" else "#{ancestry}#{self.ancestry_delimiter}#{node.id}" end
         end
       end
     end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -3,7 +3,7 @@ class << ActiveRecord::Base
     # Check options
     raise Ancestry::AncestryException.new("Options for has_ancestry must be in a hash.") unless options.is_a? Hash
     options.each do |key, value|
-      unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column].include? key
+      unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :ancestry_delimiter].include? key
         raise Ancestry::AncestryException.new("Unknown option for has_ancestry: #{key.inspect} => #{value.inspect}.")
       end
     end
@@ -22,12 +22,16 @@ class << ActiveRecord::Base
     cattr_reader :orphan_strategy
     self.orphan_strategy = options[:orphan_strategy] || :destroy
 
+    # Specify ancestry delimiter or default (writer comes from DynamicClassMethods)
+    cattr_reader :ancestry_delimiter
+    self.ancestry_delimiter = options[:ancestry_delimiter] || "/"
+
     # Save self as base class (for STI)
     cattr_accessor :base_class
     self.base_class = self
     
     # Validate format of ancestry column value
-    validates_format_of ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
+    validates_format_of ancestry_column, :with => lambda{|record| record.class.ancestry_pattern}, :allow_nil => true
 
     # Validate that the ancestor ids don't include own id
     validate :ancestry_exclude_self

--- a/test/has_ancestry_test.rb
+++ b/test/has_ancestry_test.rb
@@ -52,6 +52,26 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_default_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      assert_equal "/", model.ancestry_delimiter
+    end
+  end
+
+  def test_non_default_orphan_strategy
+    AncestryTestDatabase.with_model :ancestry_delimiter => ',' do |model|
+      assert_equal ',', model.ancestry_delimiter
+    end
+  end
+
+  def test_setting_invalid_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      assert_raise Ancestry::AncestryException do
+        model.ancestry_delimiter = '1'
+      end
+    end
+  end
+
   def test_scoping_in_callbacks
     AncestryTestDatabase.with_model do |model|
       $random_object = model.create


### PR DESCRIPTION
The default delimiter remains `'/'`, but it is now configurable. When using Mysql, setting the delimiter to `','` allows you to use the `FIND_IN_SET` function against the ancestry column, which can be useful in certain situations.

This works correctly against the current version of Rails, but older versions do not allow passing a lambda to `validates_format_of`. Depending on input from other users, we can keep it backward compatible by validating with a custom validator or adding an instance method.