### PR TITLE
Add support for PostgresSQL's native UUID column types.

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -226,7 +226,7 @@ module Ancestry
   private
 
     def cast_primary_key(key)
-      if primary_key_type == :string
+      if [:string, :uuid].include? primary_key_type
         key
       else
         key.to_i


### PR DESCRIPTION
Adds support for PostgreSQL's native UUID column type by checking for either `:string` or `:uuid` (instead of just `:string` ) in the `cast_primary_key` method in `lib/ancestry/instance_methods.rb:228`

Backstory:

I'm working on a project (Ruby 1.9.3, Rails 4.0.0rc1) where I have UUIDs as primary_keys on my model. I'm running PostgreSQL locally, and taking advantage of it's native UUID column support (which is an 128-bit integer, not a string).

This became a problem when trying to utilize Ancestry's instance methods; When looking at `Instance.parent_id`,  I saw that my UUID was converted to an integer (`882b610e-9d5a-4e64-a240-1143f0af22b8` became just `882`), and so none of the related ancestors/descendants could be found. I traced the issue down to `/lib/ancestry/instance_methods.rb:228`, the `cast_primary_key` method:

``` ruby
def cast_primary_key(key)
  if primary_key_type == :string
    key
  else
    key.to_i
  end
end
```

Overriding this in my app (my_app/lib/ancestry/instance_methods.rb) with the following resolved the issue:

``` ruby
module Ancestry
  module InstanceMethods

  private

    def cast_primary_key(key)
      if [:string, :uuid].include? primary_key_type
        key
      else
        key.to_i
      end
    end

    def primary_key_type
      @primary_key_type ||= column_for_attribute(self.class.primary_key).type
    end

  end
end
```
