### PR TITLE
Pass options to arrange_serializable

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -172,6 +172,10 @@ The result of arrange_serializable can easily be serialized to json with 'to_jso
 
   TreeNode.arrange_serializable.to_json
 
+You can also pass the order to the arrange_serializable method just as you can pass it to the arrange method:
+
+  TreeNode.arrange_serializable(:order => :name)
+
 = Sorting
 
 If you just want to sort an array of nodes as if you were traversing them in preorder, you can use the sort_by_ancestry class method:

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -56,10 +56,11 @@ module Ancestry
       end
     end
 
-    # Arrangement to nested array
-    def arrange_serializable nodes = arrange
+     # Arrangement to nested array
+    def arrange_serializable options={}, nodes=nil
+      nodes = arrange(options) if nodes.nil?
       nodes.map do |parent, children|
-        parent.serializable_hash.merge 'children' => arrange_serializable(children)
+        parent.serializable_hash.merge 'children' => arrange_serializable(options, children)
       end
     end
 

--- a/test/has_ancestry_test.rb
+++ b/test/has_ancestry_test.rb
@@ -430,16 +430,19 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
   end
 
   def test_arrange_serializable
-    AncestryTestDatabase.with_model :depth => 2, :width => 1 do |model, roots|
-      result = [
-        {
-          'ancestry' => nil, 'id' => 1, 'children' => [
-            { 'ancestry' => '1', 'id' => 2, 'children' => [] }
-          ]
-        }
-      ]
+    AncestryTestDatabase.with_model :depth => 2, :width => 2 do |model, roots|
+      result = [{"ancestry"=>nil,
+          "id"=>4,
+          "children"=>
+           [{"ancestry"=>"4", "id"=>6, "children"=>[]},
+            {"ancestry"=>"4", "id"=>5, "children"=>[]}]},
+         {"ancestry"=>nil,
+          "id"=>1,
+          "children"=>
+           [{"ancestry"=>"1", "id"=>3, "children"=>[]},
+            {"ancestry"=>"1", "id"=>2, "children"=>[]}]}]
 
-      assert_equal model.arrange_serializable, result
+      assert_equal model.arrange_serializable(order: "id desc"), result
     end
   end
 


### PR DESCRIPTION
This allows options to be passed to arrange_serializable in the same way they can be passed to arrange. Specifically I wrote this so I could use the "order" option.
