### PR TITLE
Wrap rebuild_depth_cache! in a transaction

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -185,9 +185,11 @@ module Ancestry
     def rebuild_depth_cache!
       raise Ancestry::AncestryException.new("Cannot rebuild depth cache for model without depth caching.") unless respond_to? :depth_cache_column
 
-      self.ancestry_base_class.unscoped do
-        self.ancestry_base_class.find_each do |node|
-          node.update_attribute depth_cache_column, node.depth
+      self.ancestry_base_class.transaction do
+        self.ancestry_base_class.unscoped do
+          self.ancestry_base_class.find_each do |node|
+            node.update_attribute depth_cache_column, node.depth
+          end
         end
       end
     end


### PR DESCRIPTION
On mysql this results in a noticeable speedup even for only 330 rows.

```
RAILS_ENV=production bin/rails runner 'Benchmark.bm(30) { |bm| bm.report("no transaction") { 100.times { Review.rebuild_depth_cache! } }; bm.report("transaction") { 100.times { Review.transaction { Review.rebuild_depth_cache! } } } }'
                                     user     system      total        real
no transaction                 168.810000   4.430000 173.240000 (198.513645)
transaction                    151.410000   3.350000 154.760000 (166.877698)
```

Moving the transaction inside the method, as in this patch, nets:

```
RAILS_ENV=production bin/rails runner 'Benchmark.bm(30) { |bm| bm.report("transaction") { 100.times { Review.rebuild_depth_cache! } } }'
                                     user     system      total        real
transaction                    149.780000   3.540000 153.320000 (165.597339)
```

Alternately, suggesting wrapping it in a transaction in the docs might help others with much larger datasets.
