### PR TITLE
allow ids that matches word characters

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,5 +4,5 @@ require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+  ANCESTRY_PATTERN = /\A\w+(\/\w+)*\Z/
 end

--- a/test/concerns/integrity_checking_and_restoration_test.rb
+++ b/test/concerns/integrity_checking_and_restoration_test.rb
@@ -12,7 +12,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
 
     AncestryTestDatabase.with_model :width => 3, :depth => 3 do |model, roots|
       # Check detection of invalid format for ancestry column
-      roots.first.first.update_attribute model.ancestry_column, 'invalid_ancestry'
+      roots.first.first.update_attribute model.ancestry_column, 'invalid ancestry'
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -1,14 +1,20 @@
 require_relative '../environment'
 
 class ValidationsTest < ActiveSupport::TestCase
-  def test_ancestry_column_validation
+  def valid_when_ancestry_column_value_has_correct_format
     AncestryTestDatabase.with_model do |model|
       node = model.create
-      ['3', '10/2', '1/4/30', nil].each do |value|
+      ['3', 'A', '10/2', '1/4/30', 'a/b', 'CODE_01/CODE_02/CODE_03', nil].each do |value| #
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
-      ['1/3/', '/2/3', 'a', 'a/b', '-34', '/54'].each do |value|
+    end
+  end
+
+  def test_invalid_when_ancetry_column_value_is_malformed
+    AncestryTestDatabase.with_model do |model|
+      node = model.create
+      ['1/3/', '/2/3', '-34', '/54'].each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert !node.errors[model.ancestry_column].blank?
       end


### PR DESCRIPTION
Simple change in the code that allows using string id columns with other than numerical characters. With this change it is pretty easy to create e.g. geography tree that has ISO 3166-1 alpha-3 + regions with custom code. Or language trees, where a root can be e.g. English (en) but its children can have region information like US English (en_US).