### PR TITLE
Restore Ruby 1.8.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 rvm:
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
@@ -20,6 +21,12 @@ gemfile:
 
 matrix:
   exclude:
+    - rvm: 1.8.7
+      gemfile: gemfiles/sqlite3_ar_40.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/mysql_ar_40.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/pg_ar_40.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/sqlite3_ar_40.gemfile
     - rvm: 1.9.2

--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,7 @@
     appraise "#{db_type}-ar-#{ar_version.split('.').first(2).join}" do
       gem 'activerecord', ar_version
       gem db_type
+      gem 'mime-types', '~> 1.0', :platforms => :ruby_18
     end
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'appraisal', '1.0.0.beta1'
-gem 'debugger'
+gem 'debugger', :platforms => [:ruby_19, :ruby_20, :ruby_21]
 gem 'rdoc'
 gem 'coveralls', require: false
 gem 'activerecord', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ancestry (2.0.0)
+    ancestry (2.1.0)
       activerecord (>= 3.0.0)
 
 GEM

--- a/gemfiles/mysql_ar_30.gemfile
+++ b/gemfiles/mysql_ar_30.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.0.20"
 gem "mysql"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/mysql_ar_30.gemfile.lock
+++ b/gemfiles/mysql_ar_30.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -24,20 +30,21 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
-    i18n (0.5.0)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
+    i18n (0.5.3)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
     mysql (2.9.1)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -46,19 +53,22 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.0.20)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   mysql
+  pg
   rdoc

--- a/gemfiles/mysql_ar_31.gemfile
+++ b/gemfiles/mysql_ar_31.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.1.12"
 gem "mysql"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/mysql_ar_31.gemfile.lock
+++ b/gemfiles/mysql_ar_31.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,20 +31,21 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
     mysql (2.9.1)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -47,19 +54,22 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.1.12)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   mysql
+  pg
   rdoc

--- a/gemfiles/mysql_ar_32.gemfile
+++ b/gemfiles/mysql_ar_32.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.2.14"
 gem "mysql"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/mysql_ar_32.gemfile.lock
+++ b/gemfiles/mysql_ar_32.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,20 +31,21 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
     mysql (2.9.1)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -47,19 +54,22 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.2.14)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   mysql
+  pg
   rdoc

--- a/gemfiles/mysql_ar_40.gemfile
+++ b/gemfiles/mysql_ar_40.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "4.0.1"
 gem "mysql"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/mysql_ar_40.gemfile.lock
+++ b/gemfiles/mysql_ar_40.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,8 +26,7 @@ GEM
       bundler
       rake
       thor (~> 0.18.1)
-    arel (4.0.1)
-    atomic (1.1.14)
+    arel (4.0.2)
     builder (3.1.4)
     columnize (0.3.6)
     coveralls (0.7.0)
@@ -30,21 +35,22 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
+    mime-types (1.25.1)
     minitest (4.7.5)
-    multi_json (1.8.2)
+    multi_json (1.9.2)
     mysql (2.9.1)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -53,21 +59,23 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    thread_safe (0.1.3)
-      atomic
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    thread_safe (0.3.3)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 4.0.1)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   mysql
+  pg
   rdoc

--- a/gemfiles/pg_ar_30.gemfile
+++ b/gemfiles/pg_ar_30.gemfile
@@ -3,8 +3,11 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
 gem "activerecord", "3.0.20"
 gem "pg"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/pg_ar_30.gemfile.lock
+++ b/gemfiles/pg_ar_30.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -24,20 +30,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
-    i18n (0.5.0)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
+    i18n (0.5.3)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    pg (0.16.0)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -46,19 +52,21 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.0.20)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   pg
   rdoc

--- a/gemfiles/pg_ar_31.gemfile
+++ b/gemfiles/pg_ar_31.gemfile
@@ -3,8 +3,11 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
 gem "activerecord", "3.1.12"
 gem "pg"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/pg_ar_31.gemfile.lock
+++ b/gemfiles/pg_ar_31.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,20 +31,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    pg (0.16.0)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -47,19 +53,21 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.1.12)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   pg
   rdoc

--- a/gemfiles/pg_ar_32.gemfile
+++ b/gemfiles/pg_ar_32.gemfile
@@ -3,8 +3,11 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
 gem "activerecord", "3.2.14"
 gem "pg"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/pg_ar_32.gemfile.lock
+++ b/gemfiles/pg_ar_32.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,20 +31,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    pg (0.16.0)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -47,19 +53,21 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.2.14)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   pg
   rdoc

--- a/gemfiles/pg_ar_40.gemfile
+++ b/gemfiles/pg_ar_40.gemfile
@@ -3,8 +3,11 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
 gem "activerecord", "4.0.1"
 gem "pg"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/pg_ar_40.gemfile.lock
+++ b/gemfiles/pg_ar_40.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,8 +26,7 @@ GEM
       bundler
       rake
       thor (~> 0.18.1)
-    arel (4.0.1)
-    atomic (1.1.14)
+    arel (4.0.2)
     builder (3.1.4)
     columnize (0.3.6)
     coveralls (0.7.0)
@@ -30,21 +35,21 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
+    mime-types (1.25.1)
     minitest (4.7.5)
-    multi_json (1.8.2)
-    pg (0.16.0)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -53,21 +58,22 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    thread_safe (0.1.3)
-      atomic
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    thread_safe (0.3.3)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 4.0.1)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
   pg
   rdoc

--- a/gemfiles/sqlite3_ar_30.gemfile
+++ b/gemfiles/sqlite3_ar_30.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.0.20"
 gem "sqlite3"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/sqlite3_ar_30.gemfile.lock
+++ b/gemfiles/sqlite3_ar_30.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -24,19 +30,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
-    i18n (0.5.0)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
+    i18n (0.5.3)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -45,20 +52,23 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    sqlite3 (1.3.8)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    sqlite3 (1.3.9)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.0.20)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
+  pg
   rdoc
   sqlite3

--- a/gemfiles/sqlite3_ar_31.gemfile
+++ b/gemfiles/sqlite3_ar_31.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.1.12"
 gem "sqlite3"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/sqlite3_ar_31.gemfile.lock
+++ b/gemfiles/sqlite3_ar_31.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,19 +31,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -46,20 +53,23 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    sqlite3 (1.3.8)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    sqlite3 (1.3.9)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.1.12)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
+  pg
   rdoc
   sqlite3

--- a/gemfiles/sqlite3_ar_32.gemfile
+++ b/gemfiles/sqlite3_ar_32.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "3.2.14"
 gem "sqlite3"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/sqlite3_ar_32.gemfile.lock
+++ b/gemfiles/sqlite3_ar_32.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,19 +31,20 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    mime-types (1.25.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -46,20 +53,23 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    sqlite3 (1.3.8)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    sqlite3 (1.3.9)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 3.2.14)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
+  pg
   rdoc
   sqlite3

--- a/gemfiles/sqlite3_ar_40.gemfile
+++ b/gemfiles/sqlite3_ar_40.gemfile
@@ -3,8 +3,12 @@
 source "https://rubygems.org"
 
 gem "appraisal", "1.0.0.beta1"
-gem "debugger"
+gem "debugger", :platforms=>[:ruby_19, :ruby_20, :ruby_21]
 gem "rdoc"
 gem "coveralls", :require=>false
+gem "pg"
 gem "activerecord", "4.0.1"
 gem "sqlite3"
+gem "mime-types", "~> 1.0", :platforms=>:ruby_18
+
+gemspec :path=>".././"

--- a/gemfiles/sqlite3_ar_40.gemfile.lock
+++ b/gemfiles/sqlite3_ar_40.gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .././
+  specs:
+    ancestry (2.1.0)
+      activerecord (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,8 +26,7 @@ GEM
       bundler
       rake
       thor (~> 0.18.1)
-    arel (4.0.1)
-    atomic (1.1.14)
+    arel (4.0.2)
     builder (3.1.4)
     columnize (0.3.6)
     coveralls (0.7.0)
@@ -30,20 +35,21 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
+      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
-    docile (1.1.1)
+    debugger-ruby_core_source (1.3.2)
+    docile (1.1.3)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.0)
+    mime-types (1.25.1)
     minitest (4.7.5)
-    multi_json (1.8.2)
-    rake (10.1.0)
-    rdoc (4.0.1)
+    multi_json (1.9.2)
+    pg (0.17.1)
+    rake (10.3.0)
+    rdoc (4.1.1)
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -52,22 +58,24 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    sqlite3 (1.3.8)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    sqlite3 (1.3.9)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     thor (0.18.1)
-    thread_safe (0.1.3)
-      atomic
-    tins (0.13.1)
-    tzinfo (0.3.38)
+    thread_safe (0.3.3)
+    tins (1.1.0)
+    tzinfo (0.3.39)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord (= 4.0.1)
+  ancestry!
   appraisal (= 1.0.0.beta1)
   coveralls
   debugger
+  mime-types (~> 1.0)
+  pg
   rdoc
   sqlite3

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -1,7 +1,7 @@
-require_relative 'ancestry/class_methods'
-require_relative 'ancestry/instance_methods'
-require_relative 'ancestry/exceptions'
-require_relative 'ancestry/has_ancestry'
+require File.expand_path('../ancestry/class_methods', __FILE__)
+require File.expand_path('../ancestry/instance_methods', __FILE__)
+require File.expand_path('../ancestry/exceptions', __FILE__)
+require File.expand_path('../ancestry/has_ancestry', __FILE__)
 
 module Ancestry
   ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -74,7 +74,7 @@ module Ancestry
         if self.ancestry_base_class.touch_ancestors
 
           # Touch each of the old *and* new ancestors
-          self.class.where(id: (ancestor_ids + ancestor_ids_was).uniq).each do |ancestor|
+          self.class.where(:id => (ancestor_ids + ancestor_ids_was).uniq).each do |ancestor|
             ancestor.without_ancestry_callbacks do
               ancestor.touch
             end

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class ArrangementTest < ActiveSupport::TestCase
   def test_arrangement
@@ -31,7 +31,7 @@ class ArrangementTest < ActiveSupport::TestCase
            [{"ancestry"=>"1", "id"=>3, "children"=>[]},
             {"ancestry"=>"1", "id"=>2, "children"=>[]}]}]
 
-      assert_equal model.arrange_serializable(order: "id desc"), result
+      assert_equal model.arrange_serializable(:order => "id desc"), result
     end
   end
 
@@ -40,19 +40,19 @@ class ArrangementTest < ActiveSupport::TestCase
       descending_nodes_lvl0 = model.arrange :order => 'id desc'
       ascending_nodes_lvl0 = model.arrange :order => 'id asc'
 
-      descending_nodes_lvl0.keys.zip(ascending_nodes_lvl0.keys.reverse).each do |descending_node, ascending_node|
+      Hash[descending_nodes_lvl0.keys.zip(ascending_nodes_lvl0.keys.reverse)].each do |descending_node, ascending_node|
         assert_equal descending_node, ascending_node
         descending_nodes_lvl1 = descending_nodes_lvl0[descending_node]
         ascending_nodes_lvl1 = ascending_nodes_lvl0[ascending_node]
-        descending_nodes_lvl1.keys.zip(ascending_nodes_lvl1.keys.reverse).each do |descending_node, ascending_node|
+        Hash[descending_nodes_lvl1.keys.zip(ascending_nodes_lvl1.keys.reverse)].each do |descending_node, ascending_node|
           assert_equal descending_node, ascending_node
           descending_nodes_lvl2 = descending_nodes_lvl1[descending_node]
           ascending_nodes_lvl2 = ascending_nodes_lvl1[ascending_node]
-          descending_nodes_lvl2.keys.zip(ascending_nodes_lvl2.keys.reverse).each do |descending_node, ascending_node|
+          Hash[descending_nodes_lvl2.keys.zip(ascending_nodes_lvl2.keys.reverse)].each do |descending_node, ascending_node|
             assert_equal descending_node, ascending_node
             descending_nodes_lvl3 = descending_nodes_lvl2[descending_node]
             ascending_nodes_lvl3 = ascending_nodes_lvl2[ascending_node]
-            descending_nodes_lvl3.keys.zip(ascending_nodes_lvl3.keys.reverse).each do |descending_node, ascending_node|
+            Hash[descending_nodes_lvl3.keys.zip(ascending_nodes_lvl3.keys.reverse)].each do |descending_node, ascending_node|
               assert_equal descending_node, ascending_node
             end
           end

--- a/test/concerns/build_ancestry_test.rb
+++ b/test/concerns/build_ancestry_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class BuildAncestryTest < ActiveSupport::TestCase
   def test_build_ancestry_from_parent_ids

--- a/test/concerns/default_scopes_test.rb
+++ b/test/concerns/default_scopes_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class DefaultScopesTest < ActiveSupport::TestCase
   def test_node_excluded_by_default_scope_should_still_move_with_parent

--- a/test/concerns/depth_caching_test.rb
+++ b/test/concerns/depth_caching_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class DepthCachingTest < ActiveSupport::TestCase
   def test_depth_caching

--- a/test/concerns/depth_constraints_test.rb
+++ b/test/concerns/depth_constraints_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class DepthConstraintsTest < ActiveSupport::TestCase
   def test_descendants_with_depth_constraints

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class HasAncestryTreeTest < ActiveSupport::TestCase
   def test_default_ancestry_column

--- a/test/concerns/integrity_checking_and_restoration_test.rb
+++ b/test/concerns/integrity_checking_and_restoration_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
   def test_integrity_checking

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class OphanStrategiesTest < ActiveSupport::TestCase
   def test_default_orphan_strategy

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class ScopesTest < ActiveSupport::TestCase
   def test_scopes

--- a/test/concerns/sort_by_ancestry_test.rb
+++ b/test/concerns/sort_by_ancestry_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class SortByAncestryTest < ActiveSupport::TestCase
   def test_sort_by_ancestry

--- a/test/concerns/sti_support_test.rb
+++ b/test/concerns/sti_support_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class StiSupportTest < ActiveSupport::TestCase
   def test_sti_support

--- a/test/concerns/touching_test.rb
+++ b/test/concerns/touching_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class TouchingTest < ActiveSupport::TestCase
   def test_touch_option_disabled
@@ -22,7 +22,7 @@ class TouchingTest < ActiveSupport::TestCase
       :touch => true
     ) do |model|
 
-      way_back = Time.new(1984)
+      way_back = Time.utc(1984)
       recently = Time.now - 1.minute
 
       parent_1         = model.create!(:updated_at => way_back)

--- a/test/concerns/tree_navigration_test.rb
+++ b/test/concerns/tree_navigration_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class TreeNavigationTest < ActiveSupport::TestCase
   def test_tree_navigation
@@ -13,7 +13,7 @@ class TreeNavigationTest < ActiveSupport::TestCase
         # Parent assertions
         assert_equal nil, lvl0_node.parent_id
         assert_equal nil, lvl0_node.parent
-        refute lvl0_node.parent_id?
+        assert !lvl0_node.parent_id?
         # Root assertions
         assert_equal lvl0_node.id, lvl0_node.root_id
         assert_equal lvl0_node, lvl0_node.root

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -1,4 +1,4 @@
-require_relative '../environment'
+require File.expand_path('../../environment', __FILE__)
 
 class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -14,7 +14,7 @@ SimpleCov.start do
 end
 
 require 'test/unit'
-require 'debugger'
+require 'debugger' unless RUBY_VERSION.start_with?('1.8')
 require 'logger'
 
 # Make absolutely sure we are testing local ancestry


### PR DESCRIPTION
I'm unsure if the drop in 1.8 compatibility was intentional or not in 2.1.0, but it was pretty easy to restore.  Most of the noise is from minor updates to the appraisals to ensure the Gemfile's valid on 1.8, then a handful of syntax fixes.

We rely on 1.8.7 compatibility at the moment for [Foreman](http://theforeman.org), else we'll pin the version at < 2.1.0.