### PR TITLE
Only propagating updated_at if records have been changed with touch option

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -74,9 +74,9 @@ class << ActiveRecord::Base
       }
     end
 
-    after_save :touch_ancestors_callback
     after_touch :touch_ancestors_callback
     after_destroy :touch_ancestors_callback
+    after_save :touch_ancestors_callback, if: :changed?
   end
 end
 

--- a/test/concerns/touching_test.rb
+++ b/test/concerns/touching_test.rb
@@ -16,7 +16,7 @@ class TouchingTest < ActiveSupport::TestCase
     end
   end
 
-  def test_touch_option_enabled
+  def test_touch_option_enabled_propagates_with_modification
     AncestryTestDatabase.with_model(
       :extra_columns => {:updated_at => :datetime},
       :touch => true
@@ -45,7 +45,7 @@ class TouchingTest < ActiveSupport::TestCase
     end
   end
 
-  def test_touch_option_enabled_only_propagates_when_modified
+  def test_touch_option_enabled_doesnt_propagate_without_modification
     AncestryTestDatabase.with_model(
       :extra_columns => {:updated_at => :datetime},
       :touch => true
@@ -54,9 +54,10 @@ class TouchingTest < ActiveSupport::TestCase
       way_back = Time.new(1984)
       recently = Time.now - 1.minute
 
-      parent      = model.create!(:updated_at => way_back)
-      child       = model.create!(:updated_at => way_back, :parent => parent)
-      grandchild  = model.create!(:updated_at => way_back, :parent => child)
+      parent      = model.create!
+      child       = model.create!(:parent => parent)
+      grandchild  = model.create!(:parent => child)
+      model.update_all(updated_at: way_back)
       grandchild.save
 
       assert_equal way_back, grandchild.reload.updated_at, "main record updated_at timestamp was touched"

--- a/test/concerns/touching_test.rb
+++ b/test/concerns/touching_test.rb
@@ -44,4 +44,24 @@ class TouchingTest < ActiveSupport::TestCase
       assert_equal way_back, child_1_2.reload.updated_at,        "unrelated record was touched"
     end
   end
+
+  def test_touch_option_enabled_only_propagates_when_modified
+    AncestryTestDatabase.with_model(
+      :extra_columns => {:updated_at => :datetime},
+      :touch => true
+    ) do |model|
+
+      way_back = Time.new(1984)
+      recently = Time.now - 1.minute
+
+      parent      = model.create!(:updated_at => way_back)
+      child       = model.create!(:updated_at => way_back, :parent => parent)
+      grandchild  = model.create!(:updated_at => way_back, :parent => child)
+      grandchild.save
+
+      assert_equal way_back, grandchild.reload.updated_at, "main record updated_at timestamp was touched"
+      assert_equal way_back, child.reload.updated_at,      "parent record was touched"
+      assert_equal way_back, parent.reload.updated_at,     "grandparent record was touched"
+    end
+  end
 end


### PR DESCRIPTION
This is a sister PR to the main rails one I've written rails/rails#14979. 

Basically, just adjusting the callback to only run if the record has actually changed. This brings it into line with updated_at on the main record itself which only updates if the record changed.