### PR TITLE
Added possibility to set validation regexp pattern in model instead of g...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ancestry (2.0.0)
+    ancestry (2.1.0)
       activerecord (>= 3.0.0)
 
 GEM

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -2,7 +2,3 @@ require_relative 'ancestry/class_methods'
 require_relative 'ancestry/instance_methods'
 require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
-
-module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
-end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -8,6 +8,8 @@ class << ActiveRecord::Base
       end
     end
 
+    self.const_set(:ANCESTRY_PATTERN, /\A[0-9]+(\/[0-9]+)*\Z/) unless defined?(self::ANCESTRY_PATTERN)
+
     # Include instance methods
     include Ancestry::InstanceMethods
 
@@ -31,7 +33,7 @@ class << ActiveRecord::Base
     self.touch_ancestors = options[:touch] || false
 
     # Validate format of ancestry column value
-    validates_format_of ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
+    validates_format_of ancestry_column, :with => const_get(:ANCESTRY_PATTERN), :allow_nil => true
 
     # Validate that the ancestor ids don't include own id
     validate :ancestry_exclude_self

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -294,7 +294,7 @@ module Ancestry
 
     # Validates the ancestry, but can also be applied if validation is bypassed to determine if chidren should be affected
     def sane_ancestry?
-      ancestry.nil? || (ancestry.to_s =~ Ancestry::ANCESTRY_PATTERN && !ancestor_ids.include?(self.id))
+      ancestry.nil? || (ancestry.to_s =~ self.class.const_get(:ANCESTRY_PATTERN) && !ancestor_ids.include?(self.id))
     end
 
     def unscoped_find id

--- a/test/concerns/custom_ancestry_pattern_test.rb
+++ b/test/concerns/custom_ancestry_pattern_test.rb
@@ -1,0 +1,16 @@
+require_relative '../environment'
+
+class CustomAncestryPatternTest < ActiveSupport::TestCase
+  def test_default_ancestry_pattern
+    AncestryTestDatabase.with_model :extra_columns => {:type => :string} do |model|
+      assert_equal /\A[0-9]+(\/[0-9]+)*\Z/, model::ANCESTRY_PATTERN
+    end
+  end
+
+  def test_custom_ancestry_pattern
+    AncestryTestDatabase.with_model :extra_columns => {:type => :string} do |model|
+      assert_equal /\A[0-9]+(\/[0-9]+)*\Z/, model::ANCESTRY_PATTERN
+    end
+    assert_equal /\A[\w\-]+(\/[\w\-]+)*\z/, UUIDAncestryTestDatabase::ANCESTRY_PATTERN
+  end
+end

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -104,6 +104,11 @@ class AncestryTestDatabase
   end
 end
 
+class UUIDAncestryTestDatabase < ActiveRecord::Base
+  ANCESTRY_PATTERN = /\A[\w\-]+(\/[\w\-]+)*\z/
+  has_ancestry
+end
+
 AncestryTestDatabase.setup
 
 puts "\nLoaded Ancestry test suite environment:"


### PR DESCRIPTION
We use ancestry in our project for several models. One model uses UUID format as primary key (other uses integer by default). In this case we need to have separate `ANCESTRY_PATTERN` for this model. I suggest to define this constant in model instead of globally declaration.

Let's describe in example:

```ruby
class Category < ActiveRecord::Base
  has_ancestry
end

class GlobalCategory < ActiveRecord::Base
  # lets set pattern for UUID type 
  ANCESTRY_PATTERN = /\A[\w\-]+(\/[\w\-]+)*\z/
  has_ancestry
end
``` 