### PR TITLE
Update roots scope to look for null or empty ''

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ancestry (2.0.0)
+    ancestry (2.1.0)
       activerecord (>= 3.0.0)
 
 GEM

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -18,6 +18,10 @@ class << ActiveRecord::Base
     cattr_accessor :ancestry_column
     self.ancestry_column = options[:ancestry_column] || :ancestry
 
+    def self.ancestry_arel
+      arel_table[ancestry_column]
+    end
+
     # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
     cattr_reader :orphan_strategy
     self.orphan_strategy = options[:orphan_strategy] || :destroy
@@ -37,7 +41,7 @@ class << ActiveRecord::Base
     validate :ancestry_exclude_self
 
     # Named scopes
-    scope :roots, lambda { where(ancestry_column => nil) }
+    scope :roots, lambda { where(ancestry_arel.eq(nil).or(ancestry_arel.eq(''))) }
     scope :ancestors_of, lambda { |object| where(to_node(object).ancestor_conditions) }
     scope :children_of, lambda { |object| where(to_node(object).child_conditions) }
     scope :descendants_of, lambda { |object| where(to_node(object).descendant_conditions) }


### PR DESCRIPTION
I updated the roots scope to not only look for a null ancestry column but
to also look for one which has the empty string (''). This feature came
about because of a project I'm working on where I don't control the
database, i.e. I don't have write/amend rights to the db, so I forced
them to make an `ancestry` column that follows materialized path, so I
could use the ancestry gem even for its read-only methods.

However, when they implemented it, they also created empty strings
instead of NULL columns for root nodes. This *should* be considered a
valid representation of a root node, along with a NULL column.

Because plain ActiveRecord does not deal with ORs in their queries well,
I am using plain arel. I added a convenience method to refer to the
arel_table definition of the ancestry_column, and construct the
appropriate arel query inside of the where() in the scope.