### PR TITLE
Scope for leaves

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -38,6 +38,7 @@ class << ActiveRecord::Base
 
     # Named scopes
     scope :roots, lambda { where(ancestry_column => nil) }
+    scope :leaves, lambda { joins("LEFT JOIN #{table_name} AS c ON c.#{ancestry_column} = CAST(#{table_name}.id AS text) OR c.#{ancestry_column} = #{table_name}.#{ancestry_column} || '/' || #{table_name}.id").group("#{table_name}.id").having('COUNT(c.id) = 0') }
     scope :ancestors_of, lambda { |object| where(to_node(object).ancestor_conditions) }
     scope :children_of, lambda { |object| where(to_node(object).child_conditions) }
     scope :descendants_of, lambda { |object| where(to_node(object).descendant_conditions) }

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -6,6 +6,9 @@ class ScopesTest < ActiveSupport::TestCase
       # Roots assertion
       assert_equal roots.map(&:first), model.roots.to_a
 
+      # Leaves assertion
+      assert_equal model.all.select(&:is_childless?), model.leaves.order(:id).to_a
+
       model.all.each do |test_node|
         # Assertions for ancestors_of named scope
         assert_equal test_node.ancestors.to_a, model.ancestors_of(test_node).to_a


### PR DESCRIPTION
Hi there,

Here's a pure-SQL support for getting all the leaves of the tree. Basically making sure that for every record there's other record that references it's `ancestry`. I had to use `OR` in the `JOIN` because `ancestry` might be nil.