### PR TITLE
altered ANCESTRY_PATH to accept a / separated list of UUID strings

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,5 +4,11 @@ require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+  ANCESTRY_PATTERN = %r{
+                        \A
+                        ([0-9]+(\/[0-9]+)*) #integers separated by / 
+                        |                   #or a list of UUID strings separated by /
+                        ((?<uuid>\p{XDigit}{8}-\p{XDigit}{4}-\p{XDigit}{4}-\p{XDigit}{4}-\p{XDigit}{12})(\/\g<uuid>)*)
+                        \Z     
+                     }x
 end


### PR DESCRIPTION
Hi Stefan,
I've found that ancestry wouldn't work with UUID primary keys as defined using the ActiveUUID gem (which is quite nice). The issue appears to be that the ANCESTRY_PATTERN regexp is looking for a / separated list of integer primary keys - when the  UUID primary keys are UUID strings.

I've patched the ANCESTRY_PATTERN regexp so it will accept UUID primary keys.

Kind regards

Steve