### PR TITLE
set the ancestry column delimiter and id pattern

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -118,11 +118,10 @@ The has_ancestry methods supports the following options:
                          - Migrate: add_column [table], :ancestry_depth, :integer, :default => 0
                          - Build cache: TreeNode.rebuild_depth_cache!
   :depth_cache_column    Pass in a symbol to store depth cache in a different column
-  :primary_key_format    Supply a regular expression that matches the format of your primary key.
-                         By default, primary keys only match integers ([0-9]+).
+  :primary_key_format    Supply a regular expression that matches the format of your primary key. (default: [0-9]+).
   :touch                 Instruct Ancestry to touch the ancestors of a node when it changes, to
                          invalidate nested key-based caches. (default: false)
-
+  :delimiter             The symbol used in ancestry column to separate keys (default: '/')
 = (Named) Scopes
 
 Where possible, the navigation methods return scopes instead of records, this means additional ordering, conditions, limits, etc. can be applied and that the result can be either retrieved, counted or checked for existence. For example:

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,5 +4,5 @@ require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+
 end

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -29,8 +29,7 @@ module Ancestry
 
     # Delimiter writer
     def ancestry_delimiter= ancestry_delimiter
-      # Check value of the delimiter. Restrict if it's numeric.
-      if ancestry_delimiter =~ /^\D+$/
+      if ancestry_delimiter !~ /\A#{primary_key_format}\Z/
         class_variable_set :@@ancestry_delimiter, ancestry_delimiter
       else
         raise Ancestry::AncestryException.new("Invalid delimiter, only non-numeric characters are allowed.")
@@ -38,7 +37,7 @@ module Ancestry
     end
 
     def ancestry_pattern
-      /\A[0-9]+(#{Regexp.escape(ancestry_delimiter)}[0-9]+)*\Z/
+      /\A#{primary_key_format}(?:#{Regexp.escape(ancestry_delimiter)}#{primary_key_format})*\Z/
     end
 
     # Arrangement

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -27,6 +27,20 @@ module Ancestry
       end
     end
 
+    # Delimiter writer
+    def ancestry_delimiter= ancestry_delimiter
+      # Check value of the delimiter. Restrict if it's numeric.
+      if ancestry_delimiter =~ /^\D+$/
+        class_variable_set :@@ancestry_delimiter, ancestry_delimiter
+      else
+        raise Ancestry::AncestryException.new("Invalid delimiter, only non-numeric characters are allowed.")
+      end
+    end
+
+    def ancestry_pattern
+      /\A[0-9]+(#{Regexp.escape(ancestry_delimiter)}[0-9]+)*\Z/
+    end
+
     # Arrangement
     def arrange options = {}
       scope =
@@ -168,7 +182,7 @@ module Ancestry
             # ... rebuild ancestry from parents array
             ancestry, parent = nil, parents[node.id]
             until parent.nil?
-              ancestry, parent = if ancestry.nil? then parent else "#{parent}/#{ancestry}" end, parents[parent]
+              ancestry, parent = if ancestry.nil? then parent else "#{parent}#{ancestry_delimiter}#{ancestry}" end, parents[parent]
             end
             node.without_ancestry_callbacks do
               node.update_attribute node.ancestry_column, ancestry
@@ -185,7 +199,7 @@ module Ancestry
           node.without_ancestry_callbacks do
             node.update_attribute ancestry_column, ancestry
           end
-          build_ancestry_from_parent_ids! node.id, if ancestry.nil? then "#{node.id}" else "#{ancestry}/#{node.id}" end
+          build_ancestry_from_parent_ids! node.id, if ancestry.nil? then "#{node.id}" else "#{ancestry}#{ancestry_delimiter}#{node.id}" end
         end
       end
     end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -2,16 +2,13 @@ class << ActiveRecord::Base
   def has_ancestry options = {}
     # Check options
     raise Ancestry::AncestryException.new("Options for has_ancestry must be in a hash.") unless options.is_a? Hash
-    options.each do |key, value|
-      unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :ancestry_delimiter, :touch].include? key
-        raise Ancestry::AncestryException.new("Unknown option for has_ancestry: #{key.inspect} => #{value.inspect}.")
-      end
+    invalid_keys = options.keys - [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column,
+      :ancestry_delimiter, :primary_key_format, :touch]
+    unless invalid_keys.empty?
+      raise Ancestry::AncestryException.new("Unknown option for has_ancestry: #{invalid_keys.inspect}")
     end
 
-    # Include instance methods
     include Ancestry::InstanceMethods
-
-    # Include dynamic class methods
     extend Ancestry::ClassMethods
 
     # Create ancestry column accessor and set to option or default
@@ -21,6 +18,10 @@ class << ActiveRecord::Base
     # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
     cattr_reader :orphan_strategy
     self.orphan_strategy = options[:orphan_strategy] || :destroy
+
+    # Specify pattern for ancestry ids (writer comes from DynamicClassMethods)
+    cattr_accessor :primary_key_format
+    self.primary_key_format = options[:primary_key_format] || "[0-9]+"
 
     # Specify ancestry delimiter or default (writer comes from DynamicClassMethods)
     cattr_reader :ancestry_delimiter

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -3,7 +3,7 @@ class << ActiveRecord::Base
     # Check options
     raise Ancestry::AncestryException.new("Options for has_ancestry must be in a hash.") unless options.is_a? Hash
     options.each do |key, value|
-      unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :touch].include? key
+      unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :ancestry_delimiter, :touch].include? key
         raise Ancestry::AncestryException.new("Unknown option for has_ancestry: #{key.inspect} => #{value.inspect}.")
       end
     end
@@ -22,6 +22,10 @@ class << ActiveRecord::Base
     cattr_reader :orphan_strategy
     self.orphan_strategy = options[:orphan_strategy] || :destroy
 
+    # Specify ancestry delimiter or default (writer comes from DynamicClassMethods)
+    cattr_reader :ancestry_delimiter
+    self.ancestry_delimiter = options[:ancestry_delimiter] || "/"
+
     # Save self as base class (for STI)
     cattr_accessor :ancestry_base_class
     self.ancestry_base_class = self
@@ -31,7 +35,7 @@ class << ActiveRecord::Base
     self.touch_ancestors = options[:touch] || false
 
     # Validate format of ancestry column value
-    validates_format_of ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
+    validates_format_of ancestry_column, :with => ancestry_pattern, :allow_nil => true
 
     # Validate that the ancestor ids don't include own id
     validate :ancestry_exclude_self

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -51,6 +51,26 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_default_primary_key_format
+    AncestryTestDatabase.with_model do |model|
+      assert_equal "[0-9]+", model.primary_key_format
+    end
+  end
+
+  def test_non_default_primary_key_format
+    AncestryTestDatabase.with_model :primary_key_format => '[A-Z]+' do |model|
+      assert_equal '[A-Z]+', model.primary_key_format
+    end
+  end
+
+  def test_setting_invalid_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      assert_raise Ancestry::AncestryException do
+        model.ancestry_delimiter = '1'
+      end
+    end
+  end
+
   def test_invalid_has_ancestry_options
     assert_raise Ancestry::AncestryException do
       Class.new(ActiveRecord::Base).has_ancestry :this_option_doesnt_exist => 42

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -22,6 +22,35 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_default_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      assert_equal "/", model.ancestry_delimiter
+    end
+  end
+
+  def test_non_default_ancestry_delimiter
+    AncestryTestDatabase.with_model :ancestry_delimiter => ',' do |model|
+      assert_equal ',', model.ancestry_delimiter
+    end
+  end
+
+  def test_setting_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      model.ancestry_column = :ancestors
+      assert_equal :ancestors, model.ancestry_column
+      model.ancestry_column = :ancestry
+      assert_equal :ancestry, model.ancestry_column
+    end
+  end
+
+  def test_setting_invalid_ancestry_delimiter
+    AncestryTestDatabase.with_model do |model|
+      assert_raise Ancestry::AncestryException do
+        model.ancestry_delimiter = '1'
+      end
+    end
+  end
+
   def test_invalid_has_ancestry_options
     assert_raise Ancestry::AncestryException do
       Class.new(ActiveRecord::Base).has_ancestry :this_option_doesnt_exist => 42

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -15,6 +15,20 @@ class ValidationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_ancestry_column_validation_with_strings
+    AncestryTestDatabase.with_model :primary_key_format => "[A-Z]+" do |model|
+      node = model.create
+      ['A', 'A/B', 'A/B/C', 'AAA/BB', nil].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert node.errors[model.ancestry_column].blank?
+      end
+      ['A-Z'].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert !node.errors[model.ancestry_column].blank?
+      end
+    end
+  end
+
   def test_validate_ancestry_exclude_self
     AncestryTestDatabase.with_model do |model|
       parent = model.create!


### PR DESCRIPTION
This is based upon #132 by @sholden 

It had some conflicts, so I brought up to date and took a few liberties. I can change attribution if you don't feel it reflects your intent / code.
1. set the `:ancestry_delimiter`
2. set the `:primary_key_format`

This should fix https://github.com/stefankroes/ancestry/issues/221 and https://github.com/stefankroes/ancestry/issues/241

Similar to #265
