### PR TITLE
Fix creating children in after_* callbacks

### DIFF
--- a/test/concerns/update_test.rb
+++ b/test/concerns/update_test.rb
@@ -1,0 +1,19 @@
+require_relative '../environment'
+
+class UpdateTest < ActiveSupport::TestCase
+  def test_node_creation_in_after_commit
+    AncestryTestDatabase.with_model do |model|
+      children=[]
+      model.instance_eval do
+        attr_accessor :idx
+        self.after_commit do
+          children << self.children.create!(:idx => self.idx - 1) if self.idx > 0
+        end
+      end
+      model.create!(:idx => 3)
+      # In the error case, the ancestry on each item will only contain the parent's id,
+      # and not the entire ancestry tree.
+      assert_equal '1/2/3', children.first.ancestry
+    end
+  end
+end


### PR DESCRIPTION
**NOTE:** REVISED for 2.1.x version of ancestry #57

Previously creating children in an after_\* callback would cause the
child's ancestry column to contain just the parent id and not the entire
ancestry path.

A workaround was to call self.reload in the after_\* callback, but this
commit makes the process work automatically.

The main issue looked to be that the child_ancestry method was using the
ancestry path before the save (using _was) which for new records was
obviously blank.

This revision uses the current value of the parent's ancestry, and adds
a child_ancestry_was method to return the old behaviour (with a more
descriptive name).

The change to update_descendants_with_new_ancestry was due to it relying
on the old behaviour. The revised version explicitly replaces the old
parent ancestry snippet (using child_ancestry_was) with the new one
path.

This addresses #33
