### PR TITLE
Unscope ancestors before touching them.

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -76,7 +76,7 @@ module Ancestry
         if self.ancestry_base_class.touch_ancestors
 
           # Touch each of the old *and* new ancestors
-          self.class.where(id: (ancestor_ids + ancestor_ids_was).uniq).each do |ancestor|
+          unscoped_current_and_previous_ancestors.each do |ancestor|
             ancestor.without_ancestry_callbacks do
               ancestor.touch
             end
@@ -315,6 +315,12 @@ module Ancestry
     def unscoped_descendants
       self.ancestry_base_class.unscoped do
         self.ancestry_base_class.where descendant_conditions
+      end
+    end
+
+    def unscoped_current_and_previous_ancestors
+      self.ancestry_base_class.unscoped do
+        self.ancestry_base_class.where id: (ancestor_ids + ancestor_ids_was).uniq
       end
     end
 


### PR DESCRIPTION
I've been having an issue whereby creating a child using the scoped syntax, (e.g. `grandchild.children.create`) will not touch the ancestors due to the implicit scope applied.

It looks like back when the `unscoped` method was applied to various operations in eeadeef and cd268b6, the `touch` stuff wasn't implemented yet.

Test created to demonstrate the use case.
