### PR TITLE
Fix child_ancestry for new models

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -90,7 +90,7 @@ module Ancestry
       # New records cannot have children
       raise Ancestry::AncestryException.new('No child ancestry for new record. Save record before performing tree operations.') if new_record?
 
-      if self.send("#{self.ancestry_base_class.ancestry_column}_was").blank? then id.to_s else "#{self.send "#{self.ancestry_base_class.ancestry_column}_was"}/#{id}" end
+      "#{self.send "#{self.ancestry_base_class.ancestry_column}"}/#{id}"
     end
 
     # Ancestors

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -90,7 +90,7 @@ module Ancestry
       # New records cannot have children
       raise Ancestry::AncestryException.new('No child ancestry for new record. Save record before performing tree operations.') if new_record?
 
-      "#{self.send "#{self.ancestry_base_class.ancestry_column}"}/#{id}"
+      [self.send(ancestry_base_class.ancestry_column), id].compact.join("/")
     end
 
     # Ancestors


### PR DESCRIPTION
The child_ancestry method was returning id if the ancestry column was previously blank, for example for a new model. 

This is incorrect for non-root nodes, and leads to broken ancestry relations. I discovered this due to a model mis-creating children during an after_create callback. 

This PR will fix this, but may break whatever issue the former condition was added to address.
