### PR TITLE
Add siblings-only finders (excluding the targeted node)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,28 +76,30 @@ You can also create children through the children relation on a node:
 
 To navigate an Ancestry model, use the following methods on any instance / record:
 
-  parent           Returns the parent of the record, nil for a root node
-  parent_id        Returns the id of the parent of the record, nil for a root node
-  root             Returns the root of the tree the record is in, self for a root node
-  root_id          Returns the id of the root of the tree the record is in
-  root?, is_root?  Returns true if the record is a root node, false otherwise
-  ancestor_ids     Returns a list of ancestor ids, starting with the root id and ending with the parent id
-  ancestors        Scopes the model on ancestors of the record
-  path_ids         Returns a list the path ids, starting with the root id and ending with the node's own id
-  path             Scopes model on path records of the record
-  children         Scopes the model on children of the record
-  child_ids        Returns a list of child ids
-  has_children?    Returns true if the record has any children, false otherwise
-  is_childless?    Returns true is the record has no children, false otherwise
-  siblings         Scopes the model on siblings of the record, the record itself is included*
-  sibling_ids      Returns a list of sibling ids
-  has_siblings?    Returns true if the record's parent has more than one child
-  is_only_child?   Returns true if the record is the only child of its parent
-  descendants      Scopes the model on direct and indirect children of the record
-  descendant_ids   Returns a list of a descendant ids
-  subtree          Scopes the model on descendants and itself
-  subtree_ids      Returns a list of all ids in the record's subtree
-  depth            Return the depth of the node, root nodes are at depth 0
+  parent            Returns the parent of the record, nil for a root node
+  parent_id         Returns the id of the parent of the record, nil for a root node
+  root              Returns the root of the tree the record is in, self for a root node
+  root_id           Returns the id of the root of the tree the record is in
+  root?, is_root?   Returns true if the record is a root node, false otherwise
+  ancestor_ids      Returns a list of ancestor ids, starting with the root id and ending with the parent id
+  ancestors         Scopes the model on ancestors of the record
+  path_ids          Returns a list the path ids, starting with the root id and ending with the node's own id
+  path              Scopes model on path records of the record
+  children          Scopes the model on children of the record
+  child_ids         Returns a list of child ids
+  has_children?     Returns true if the record has any children, false otherwise
+  is_childless?     Returns true is the record has no children, false otherwise
+  siblings          Scopes the model on siblings of the record, the record itself is included*
+  sibling_ids       Returns a list of sibling ids
+  siblings_only     Scopes the model on siblings of the record, the record is excluded*
+  siblings_only_ids Returns a list of sibling ids, excluding the record
+  has_siblings?     Returns true if the record's parent has more than one child
+  is_only_child?    Returns true if the record is the only child of its parent
+  descendants       Scopes the model on direct and indirect children of the record
+  descendant_ids    Returns a list of a descendant ids
+  subtree           Scopes the model on descendants and itself
+  subtree_ids       Returns a list of all ids in the record's subtree
+  depth             Return the depth of the node, root nodes are at depth 0
 
 * If the record is a root, other root records are considered siblings
 
@@ -138,6 +140,7 @@ For convenience, a couple of named scopes are included at the class level:
   descendants_of(node)    Descendants of node, node can be either a record or an id
   subtree_of(node)        Subtree of node, node can be either a record or an id
   siblings_of(node)       Siblings of node, node can be either a record or an id
+  siblings_only_of(node)  Siblings of node, excluding the node, node can be either a record or an id
 
 Thanks to some convenient rails magic, it is even possible to create nodes through the children and siblings scopes:
 

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -43,6 +43,7 @@ class << ActiveRecord::Base
     scope :descendants_of, lambda { |object| where(to_node(object).descendant_conditions) }
     scope :subtree_of, lambda { |object| where(to_node(object).subtree_conditions) }
     scope :siblings_of, lambda { |object| where(to_node(object).sibling_conditions) }
+    scope :siblings_only_of, lambda { |object| where(to_node(object).sibling_conditions(exclude_self: true)) }
     scope :ordered_by_ancestry, lambda { reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}") }
     scope :ordered_by_ancestry_and, lambda { |order| reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, #{order}") }
 

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -22,6 +22,9 @@ class ScopesTest < ActiveSupport::TestCase
         # Assertions for siblings_of named scope
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node).to_a
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node.id).to_a
+        # Assertions for siblings_only_of named scope
+        assert_equal test_node.siblings_only.to_a, model.siblings_only_of(test_node).to_a
+        assert_equal test_node.siblings_only.to_a, model.siblings_only_of(test_node.id).to_a
       end
     end
   end

--- a/test/concerns/tree_navigration_test.rb
+++ b/test/concerns/tree_navigration_test.rb
@@ -26,6 +26,8 @@ class TreeNavigationTest < ActiveSupport::TestCase
         # Siblings assertions
         assert_equal roots.map(&:first).map(&:id), lvl0_node.sibling_ids
         assert_equal roots.map(&:first), lvl0_node.siblings
+        assert_equal roots.map(&:first).map(&:id) - [lvl0_node.id], lvl0_node.siblings_only_ids
+        assert_equal roots.map(&:first).reject {|n| n == lvl0_node}, lvl0_node.siblings_only
         assert lvl0_node.has_siblings?
         assert !lvl0_node.is_only_child?
         # Descendants assertions
@@ -59,6 +61,8 @@ class TreeNavigationTest < ActiveSupport::TestCase
           # Siblings assertions
           assert_equal lvl0_children.map(&:first).map(&:id), lvl1_node.sibling_ids
           assert_equal lvl0_children.map(&:first), lvl1_node.siblings
+          assert_equal lvl0_children.map(&:first).map(&:id) - [lvl1_node.id], lvl1_node.siblings_only_ids
+          assert_equal lvl0_children.map(&:first).reject {|n| n == lvl1_node}, lvl1_node.siblings_only
           assert lvl1_node.has_siblings?
           assert !lvl1_node.is_only_child?
           # Descendants assertions
@@ -92,6 +96,8 @@ class TreeNavigationTest < ActiveSupport::TestCase
             # Siblings assertions
             assert_equal lvl1_children.map(&:first).map(&:id), lvl2_node.sibling_ids
             assert_equal lvl1_children.map(&:first), lvl2_node.siblings
+            assert_equal lvl1_children.map(&:first).map(&:id) - [lvl2_node.id], lvl2_node.siblings_only_ids
+            assert_equal lvl1_children.map(&:first).reject {|n| n == lvl2_node}, lvl2_node.siblings_only
             assert lvl2_node.has_siblings?
             assert !lvl2_node.is_only_child?
             # Descendants assertions


### PR DESCRIPTION
Hi,

This PR adds support for siblings-only finders and scope.

Excluding the targeted node from the list of its siblings is as simple as `node.siblings.reject { |s| s == node }`, but it might make more sense to handle that within ancestry itself so as to leverage a cleaner SQL query and improve consistency (eg. `Model.siblings_only_of(node)`, `Model#siblings_only_ids`).