### PR TITLE
fix rails 5 deprecations

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,7 +2,9 @@
   %w(3.0.20 3.1.12 3.2.22 4.0.13 4.1.14 4.2.5).each do |ar_version|
     appraise "#{db_type}-ar-#{ar_version.split('.').first(2).join}" do
       gem "activerecord", ar_version
-      gem db_type unless db_type == "sqlite3" # Skip sqlite3 since it's part of the base Gemfile.
+      gem "mysql" if db_type == "mysql"
+      gem "pg", "0.18.4" if db_type == "pg"
+      # Skip sqlite3 since it's part of the base Gemfile.
     end
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", require: false
 gem "activerecord", '~> 4.0.2'
+
+# RUBY_VERSION < "2.0"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"

--- a/gemfiles/mysql_ar_30.gemfile
+++ b/gemfiles/mysql_ar_30.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.0.20"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/mysql_ar_31.gemfile
+++ b/gemfiles/mysql_ar_31.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.1.12"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/mysql_ar_32.gemfile
+++ b/gemfiles/mysql_ar_32.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.2.22"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/mysql_ar_40.gemfile
+++ b/gemfiles/mysql_ar_40.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.0.13"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/mysql_ar_41.gemfile
+++ b/gemfiles/mysql_ar_41.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.1.14"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/mysql_ar_42.gemfile
+++ b/gemfiles/mysql_ar_42.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.2.5"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 gem "mysql"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_30.gemfile
+++ b/gemfiles/pg_ar_30.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.0.20"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_31.gemfile
+++ b/gemfiles/pg_ar_31.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.1.12"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_32.gemfile
+++ b/gemfiles/pg_ar_32.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.2.22"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_40.gemfile
+++ b/gemfiles/pg_ar_40.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.0.13"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_41.gemfile
+++ b/gemfiles/pg_ar_41.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.1.14"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/pg_ar_42.gemfile
+++ b/gemfiles/pg_ar_42.gemfile
@@ -6,6 +6,9 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.2.5"
-gem "pg"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
+gem "pg", "0.18.4"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_30.gemfile
+++ b/gemfiles/sqlite3_ar_30.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.0.20"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_31.gemfile
+++ b/gemfiles/sqlite3_ar_31.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.1.12"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_32.gemfile
+++ b/gemfiles/sqlite3_ar_32.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "3.2.22"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_40.gemfile
+++ b/gemfiles/sqlite3_ar_40.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.0.13"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_41.gemfile
+++ b/gemfiles/sqlite3_ar_41.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.1.14"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/gemfiles/sqlite3_ar_42.gemfile
+++ b/gemfiles/sqlite3_ar_42.gemfile
@@ -6,5 +6,8 @@ gem "appraisal"
 gem "rdoc"
 gem "coveralls", :require => false
 gem "activerecord", "4.2.5"
+gem "json", "~> 1.8.3"
+gem "term-ansicolor", "~> 1.3.2"
+gem "tins", "~> 1.6.0"
 
 gemspec :path => "../"

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -116,14 +116,14 @@ class ArrangementTest < ActiveSupport::TestCase
   def test_ancestors_arrange_middle_node
     AncestryTestDatabase.with_model :depth => 3, :width => 2 do |model, roots|
       test_node = middle_node(model)
-      arranged_nodes = test_node.ancestors.arrange, test_node.ancestor_ids
+      assert_tree_path test_node.ancestors.arrange, test_node.ancestor_ids
     end
   end
 
   def test_ancestors_arrange_leaf_node
     AncestryTestDatabase.with_model :depth => 3, :width => 2 do |model, roots|
       test_node = leaf_node(model)
-      arranged_nodes = test_node.ancestors.arrange, test_node.ancestor_ids
+      assert_tree_path test_node.ancestors.arrange, test_node.ancestor_ids
     end
   end
 
@@ -171,20 +171,20 @@ class ArrangementTest < ActiveSupport::TestCase
       descending_nodes_lvl0 = model.arrange :order => 'id desc'
       ascending_nodes_lvl0 = model.arrange :order => 'id asc'
 
-      descending_nodes_lvl0.keys.zip(ascending_nodes_lvl0.keys.reverse).each do |descending_node, ascending_node|
-        assert_equal descending_node, ascending_node
-        descending_nodes_lvl1 = descending_nodes_lvl0[descending_node]
-        ascending_nodes_lvl1 = ascending_nodes_lvl0[ascending_node]
-        descending_nodes_lvl1.keys.zip(ascending_nodes_lvl1.keys.reverse).each do |descending_node, ascending_node|
-          assert_equal descending_node, ascending_node
-          descending_nodes_lvl2 = descending_nodes_lvl1[descending_node]
-          ascending_nodes_lvl2 = ascending_nodes_lvl1[ascending_node]
-          descending_nodes_lvl2.keys.zip(ascending_nodes_lvl2.keys.reverse).each do |descending_node, ascending_node|
-            assert_equal descending_node, ascending_node
-            descending_nodes_lvl3 = descending_nodes_lvl2[descending_node]
-            ascending_nodes_lvl3 = ascending_nodes_lvl2[ascending_node]
-            descending_nodes_lvl3.keys.zip(ascending_nodes_lvl3.keys.reverse).each do |descending_node, ascending_node|
-              assert_equal descending_node, ascending_node
+      descending_nodes_lvl0.keys.zip(ascending_nodes_lvl0.keys.reverse).each do |descending_node1, ascending_node1|
+        assert_equal descending_node1, ascending_node1
+        descending_nodes_lvl1 = descending_nodes_lvl0[descending_node1]
+        ascending_nodes_lvl1 = ascending_nodes_lvl0[ascending_node1]
+        descending_nodes_lvl1.keys.zip(ascending_nodes_lvl1.keys.reverse).each do |descending_node2, ascending_node2|
+          assert_equal descending_node2, ascending_node2
+          descending_nodes_lvl2 = descending_nodes_lvl1[descending_node2]
+          ascending_nodes_lvl2 = ascending_nodes_lvl1[ascending_node2]
+          descending_nodes_lvl2.keys.zip(ascending_nodes_lvl2.keys.reverse).each do |descending_node3, ascending_node3|
+            assert_equal descending_node3, ascending_node3
+            descending_nodes_lvl3 = descending_nodes_lvl2[descending_node3]
+            ascending_nodes_lvl3 = ascending_nodes_lvl2[ascending_node3]
+            descending_nodes_lvl3.keys.zip(ascending_nodes_lvl3.keys.reverse).each do |descending_node4, ascending_node4|
+              assert_equal descending_node4, ascending_node4
             end
           end
         end

--- a/test/concerns/build_ancestry_test.rb
+++ b/test/concerns/build_ancestry_test.rb
@@ -3,10 +3,10 @@ require_relative '../environment'
 class BuildAncestryTest < ActiveSupport::TestCase
   def test_build_ancestry_from_parent_ids
     AncestryTestDatabase.with_model :skip_ancestry => true, :extra_columns => {:parent_id => :integer} do |model|
-      [model.create!].each do |parent|
-        (Array.new(5) { model.create! :parent_id => parent.id }).each do |parent|
-          (Array.new(5) { model.create! :parent_id => parent.id }).each do |parent|
-            (Array.new(5) { model.create! :parent_id => parent.id })
+      [model.create!].each do |parent1|
+        (Array.new(5) { model.create! :parent_id => parent1.id }).each do |parent2|
+          (Array.new(5) { model.create! :parent_id => parent2.id }).each do |parent3|
+            (Array.new(5) { model.create! :parent_id => parent3.id })
           end
         end
       end
@@ -27,14 +27,14 @@ class BuildAncestryTest < ActiveSupport::TestCase
       assert_equal 1, roots.size
 
       # Assert it has 5 children
-      roots.each do |parent|
-        assert_equal 5, parent.children.count
-        parent.children.each do |parent|
-          assert_equal 5, parent.children.count
-          parent.children.each do |parent|
-            assert_equal 5, parent.children.count
-            parent.children.each do |parent|
-              assert_equal 0, parent.children.count
+      roots.each do |parent1|
+        assert_equal 5, parent1.children.count
+        parent1.children.each do |parent2|
+          assert_equal 5, parent2.children.count
+          parent2.children.each do |parent3|
+            assert_equal 5, parent3.children.count
+            parent3.children.each do |parent4|
+              assert_equal 0, parent4.children.count
             end
           end
         end

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -59,7 +59,7 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
 
   def test_set_parent_with_non_default_ancestry_column
     AncestryTestDatabase.with_model :depth => 3, :width => 3, :ancestry_column => :alternative_ancestry do |model, roots|
-      root1, root2, root3 = roots.map(&:first)
+      root1, root2, _root3 = roots.map(&:first)
       assert_no_difference 'root1.descendants.size' do
         assert_difference 'root2.descendants.size', root1.subtree.size do
           root1.parent = root2
@@ -73,18 +73,18 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
       assert_equal Array, roots.class
       assert_equal 3, roots.length
-      roots.each do |node, children|
-        assert_equal model, node.class
-        assert_equal Array, children.class
-        assert_equal 3, children.length
-        children.each do |node, children|
-          assert_equal model, node.class
-          assert_equal Array, children.class
-          assert_equal 3, children.length
-          children.each do |node, children|
-            assert_equal model, node.class
-            assert_equal Array, children.class
-            assert_equal 0, children.length
+      roots.each do |node1, children1|
+        assert_equal model, node1.class
+        assert_equal Array, children1.class
+        assert_equal 3, children1.length
+        children1.each do |node2, children2|
+          assert_equal model, node2.class
+          assert_equal Array, children2.class
+          assert_equal 3, children2.length
+          children2.each do |node3, children3|
+            assert_equal model, node3.class
+            assert_equal Array, children3.class
+            assert_equal 0, children3.length
           end
         end
       end

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -65,7 +65,7 @@ class OphanStrategiesTest < ActiveSupport::TestCase
       assert_raise Ancestry::AncestryException do
         root.destroy
       end
-      assert_nothing_raised Ancestry::AncestryException do
+      assert_nothing_raised do
         root.children.first.children.first.destroy
       end
     end

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -63,7 +63,7 @@ class ScopesTest < ActiveSupport::TestCase
       end
 
       parent = model.create
-      assert child = parent.children.create
+      assert parent.children.create
     end
   end
 end

--- a/test/concerns/touching_test.rb
+++ b/test/concerns/touching_test.rb
@@ -12,7 +12,7 @@ class TouchingTest < ActiveSupport::TestCase
       child  = model.create!(:updated_at => yesterday, :parent => parent)
 
       child.update_attributes(:name => "Changed")
-      assert_equal yesterday, parent.updated_at
+      assert_equal yesterday.utc.change(:usec => 0), parent.updated_at.utc.change(:usec => 0)
     end
   end
 
@@ -52,7 +52,6 @@ class TouchingTest < ActiveSupport::TestCase
     ) do |model|
 
       way_back = Time.new(1984)
-      recently = Time.now - 1.minute
 
       parent      = model.create!
       child       = model.create!(:parent => parent)

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -27,7 +27,7 @@ class AncestryTestDatabase
     ActiveRecord::Base.logger.level = Logger::Severity::UNKNOWN
 
     # Assume Travis CI database config if no custom one exists
-    filename = if File.exists?(File.expand_path('../database.yml', __FILE__))
+    filename = if File.exist?(File.expand_path('../database.yml', __FILE__))
       File.expand_path('../database.yml', __FILE__)
     else
       File.expand_path('../database.ci.yml', __FILE__)


### PR DESCRIPTION
pegging some gems to ruby 1.9.3 compatible versions

goal is to make ancestry 2.x green

fix rails 5 deprecations before upgrading to 3.x and adding rails 5.x

ancestry 3.x will drop 1.9.3 support and drop many of these gemfile changes
