### PR TITLE
introduce path_of scope

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -45,6 +45,7 @@ class << ActiveRecord::Base
     scope :siblings_of, lambda { |object| where(to_node(object).sibling_conditions) }
     scope :ordered_by_ancestry, lambda { reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}") }
     scope :ordered_by_ancestry_and, lambda { |order| reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, #{order}") }
+    scope :path_of, lambda { |object| to_node(object).path }
 
     # Update descendants with new ancestry before save
     before_save :update_descendants_with_new_ancestry

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -22,6 +22,9 @@ class ScopesTest < ActiveSupport::TestCase
         # Assertions for siblings_of named scope
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node).to_a
         assert_equal test_node.siblings.to_a, model.siblings_of(test_node.id).to_a
+        # Assertions for path_of named scope
+        assert_equal test_node.path.to_a, model.path_of(test_node).to_a
+        assert_equal test_node.path.to_a, model.path_of(test_node.id).to_a
       end
     end
   end


### PR DESCRIPTION
long term goal: 
Moving all scope manipulation over to the class rather than having that logic in the instances.

Added `path_of` to the class so we can migrate all arel over to the model.