### PR TITLE
No longer cast text columns as ints

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -301,7 +301,7 @@ module Ancestry
   private
 
     def cast_primary_key(key)
-      if [:string, :uuid].include? primary_key_type
+      if [:string, :uuid, :text].include? primary_key_type
         key
       else
         key.to_i


### PR DESCRIPTION
Would be nice to tap into active record but
for now, just skipping the cast for text columns

fixes #236