### PR TITLE
cache travis bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+cache: bundler
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
Since all the builds use a different version of the gems, not sure if bundle cache will help here

testing it out