### PR TITLE
Use pluck instead of select + map

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -206,7 +206,7 @@ module Ancestry
     end
 
     def child_ids
-      children.select(self.ancestry_base_class.primary_key).map(&self.ancestry_base_class.primary_key.to_sym)
+      children.pluck(self.ancestry_base_class.primary_key)
     end
 
     def has_children?
@@ -235,7 +235,7 @@ module Ancestry
     end
 
     def sibling_ids
-      siblings.select(self.ancestry_base_class.primary_key).collect(&self.ancestry_base_class.primary_key.to_sym)
+      siblings.pluck(self.ancestry_base_class.primary_key)
     end
 
     def has_siblings?
@@ -269,7 +269,7 @@ module Ancestry
     end
 
     def descendant_ids depth_options = {}
-      descendants(depth_options).select(self.ancestry_base_class.primary_key).collect(&self.ancestry_base_class.primary_key.to_sym)
+      descendants(depth_options).pluck(self.ancestry_base_class.primary_key)
     end
 
     def descendant_of?(node)
@@ -288,7 +288,7 @@ module Ancestry
     end
 
     def subtree_ids depth_options = {}
-      subtree(depth_options).select(self.ancestry_base_class.primary_key).collect(&self.ancestry_base_class.primary_key.to_sym)
+      subtree(depth_options).pluck(self.ancestry_base_class.primary_key)
     end
 
     # Callback disabling


### PR DESCRIPTION
This avoids instantiating records with only a subset of the expected columns, which may have unintended consequences.

Specifically, our project uses default_value_for, which sets default values when the record is instantiated. When the `_ids` methods use `select`, records are instantiated without all the expected columns, causing an ActiveRecord exception when attempting to initialize the missing columns with default values. This change avoids the need to instantiate records at all, instead using the `pluck` method to return the primary key column values.