### PR TITLE
Ensure has_ancestry doesn't connect to db

### DIFF
--- a/test/concerns/db_test.rb
+++ b/test/concerns/db_test.rb
@@ -1,0 +1,13 @@
+require_relative '../environment'
+
+class DbTest < ActiveSupport::TestCase
+  def test_does_not_load_database
+    c = Class.new(ActiveRecord::Base) do
+      def self.connection
+        raise "Oh No - tried to connect to database"
+      end
+    end
+
+    c.send(:has_ancestry)
+  end
+end


### PR DESCRIPTION
Added a test to ensure we are not connecting to the database at class definition time

/cc @Fryguy good idea
/cc @ledermann hope this will prevent us from making this mistake again