### PR TITLE
condense order_by_ancestry, order_by_ancestry_and

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -30,7 +30,7 @@ module Ancestry
     # Arrangement
     def arrange options = {}
       # Get all nodes ordered by ancestry and start sorting them into an empty hash
-      arrange_nodes self.ancestry_base_class.ordered_by_ancestry_and(options.delete(:order)).where(options)
+      arrange_nodes self.ancestry_base_class.reorder(options.delete(:order)).where(options)
     end
 
     # Arrange array of nodes into a nested hash of the form

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -29,14 +29,8 @@ module Ancestry
 
     # Arrangement
     def arrange options = {}
-      scope =
-        if options[:order].nil?
-          self.ancestry_base_class.ordered_by_ancestry
-        else
-          self.ancestry_base_class.ordered_by_ancestry_and options.delete(:order)
-        end
       # Get all nodes ordered by ancestry and start sorting them into an empty hash
-      arrange_nodes scope.where(options)
+      arrange_nodes self.ancestry_base_class.ordered_by_ancestry_and(options.delete(:order)).where(options)
     end
 
     # Arrange array of nodes into a nested hash of the form

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -47,20 +47,14 @@ class << ActiveRecord::Base
     scope :descendants_of, lambda { |object| where(descendant_conditions(object)) }
     scope :subtree_of, lambda { |object| where(subtree_conditions(object)) }
     scope :siblings_of, lambda { |object| where(sibling_conditions(object)) }
-    scope :ordered_by_ancestry, lambda {
-      if %w(mysql mysql2 sqlite postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
-        reorder("coalesce(#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, '')")
+    scope :ordered_by_ancestry, Proc.new { |order|
+      if %w(mysql mysql2 sqlite sqlite3 postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
+        reorder("coalesce(#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, '')", order)
       else
-        reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}")
+        reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}", order)
       end
     }
-    scope :ordered_by_ancestry_and, lambda { |order|
-      if %w(mysql mysql2 sqlite postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
-        reorder("coalesce(#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, ''), #{order}")
-      else
-        reorder("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}, #{order}")
-      end
-    }
+    scope :ordered_by_ancestry_and, Proc.new { |order| ordered_by_ancestry_and(order) }
     scope :path_of, lambda { |object| to_node(object).path }
 
     # Update descendants with new ancestry before save


### PR DESCRIPTION
Don't order ancestry for arrangement.

Also, no reason for duplicate code between `order_by_ancestry` and `order_by_ancestry_and` which are basically the same code

/cc @Fryguy 