### PR TITLE
Materialized path deux

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -9,22 +9,10 @@ module Ancestry
         end
       end
 
-      # Include instance methods
-      include Ancestry::InstanceMethods
-
-      # Include dynamic class methods
-      extend Ancestry::ClassMethods
-
-      # Include class methods that implement materialized path methods
-      extend Ancestry::MaterializedPath
 
       # Create ancestry column accessor and set to option or default
       cattr_accessor :ancestry_column
       self.ancestry_column = options[:ancestry_column] || :ancestry
-
-      # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
-      cattr_reader :orphan_strategy
-      self.orphan_strategy = options[:orphan_strategy] || :destroy
 
       # Save self as base class (for STI)
       cattr_accessor :ancestry_base_class
@@ -34,8 +22,17 @@ module Ancestry
       cattr_accessor :touch_ancestors
       self.touch_ancestors = options[:touch] || false
 
-      # Validate format of ancestry column value
-      validates_format_of ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
+      # Include instance methods
+      include Ancestry::InstanceMethods
+
+      # Include dynamic class methods
+      extend Ancestry::ClassMethods
+
+      extend Ancestry::MaterializedPath
+
+      # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
+      cattr_reader :orphan_strategy
+      self.orphan_strategy = options[:orphan_strategy] || :destroy
 
       # Validate that the ancestor ids don't include own id
       validate :ancestry_exclude_self

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -41,7 +41,7 @@ module Ancestry
       validate :ancestry_exclude_self
 
       # Named scopes
-      scope :roots, lambda { where(ancestry_column => nil) }
+      scope :roots, lambda { where(root_conditions) }
       scope :ancestors_of, lambda { |object| where(ancestor_conditions(object)) }
       scope :path_of, lambda { |object| where(path_conditions(object)) }
       scope :children_of, lambda { |object| where(child_conditions(object)) }

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -318,12 +318,6 @@ module Ancestry
       end
     end
 
-    # Validates the ancestry, but can also be applied if validation is bypassed to determine if children should be affected
-    def sane_ancestry?
-      ancestry_value = read_attribute(self.ancestry_base_class.ancestry_column)
-      ancestry_value.nil? || (ancestry_value.to_s =~ Ancestry::ANCESTRY_PATTERN && !ancestor_ids.include?(self.id))
-    end
-
     def unscoped_find id
       self.ancestry_base_class.unscoped { self.ancestry_base_class.find(id) }
     end

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -1,5 +1,9 @@
 module Ancestry
   module MaterializedPath
+    def root_conditions
+      arel_table[ancestry_column].eq(nil)
+    end
+
     def ancestor_conditions(object)
       t = arel_table
       node = to_node(object)

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -1,5 +1,10 @@
 module Ancestry
   module MaterializedPath
+    def self.extended(base)
+      base.validates_format_of base.ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
+      base.send(:include, InstanceMethods)
+    end
+
     def root_conditions
       arel_table[ancestry_column].eq(nil)
     end
@@ -43,6 +48,14 @@ module Ancestry
       t = arel_table
       node = to_node(object)
       t[ancestry_column].eq(node[ancestry_column])
+    end
+
+    module InstanceMethods
+      # Validates the ancestry, but can also be applied if validation is bypassed to determine if children should be affected
+      def sane_ancestry?
+        ancestry_value = read_attribute(self.ancestry_base_class.ancestry_column)
+        ancestry_value.nil? || (ancestry_value.to_s =~ Ancestry::ANCESTRY_PATTERN && !ancestor_ids.include?(self.id))
+      end
     end
   end
 end


### PR DESCRIPTION
In a perfect world, the single `ancestry` column with `/grand_id/parent_id` is just a strategy for stating the parents of a record.

This is a baby step to moving all the column specific logic into a separate module