### PR TITLE
Add ruby 2.4 support in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.4.1
 
 gemfile:
   - gemfiles/mysql_ar_42.gemfile
@@ -23,6 +24,9 @@ matrix:
       gemfile: gemfiles/pg_ar_32.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/sqlite3_ar_32.gemfile
+  exclude:
+    - rvm: 2.4.1
+      gemfile: gemfiles/mysql_ar_42.gemfile
 
 services:
   - mysql


### PR DESCRIPTION
Skip testing the mysql gem on ruby 2.4.1.
People will just use mysql2.

"The mysql gem is one of many gems which doesn't like the unification of
the integer types in Ruby 2.4.

Unfortunately, since the mysql gem isn't really maintained anymore, I
wouldn't hold my breath for an updated version. As a workaround, you can
switch to a Ruby version before 2.4, e.g. Ruby 2.3.3.

Alternatively, you could switch to the mysql2 gem which is actively
maintained, has a similar API to the mysql gem and in its latest version
is compatible with Ruby 2.4."

Thanks to Holger Just:
http://stackoverflow.com/questions/41520996/mysql-gem-install-error-on-ruby-2-4
61db43e  