### PR TITLE
Fix check for new parent_id in #parent_id=

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -152,8 +152,8 @@ module Ancestry
       write_attribute(self.ancestry_base_class.ancestry_column, if parent.nil? then nil else parent.child_ancestry end)
     end
 
-    def parent_id= parent_id
-      self.parent = ancestors? ? unscoped_find(parent_id) : nil
+    def parent_id= new_parent_id
+      self.parent = new_parent_id.present? ? unscoped_find(new_parent_id) : nil
     end
 
     def parent_id

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -69,6 +69,30 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_set_parent_id
+    AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
+      root1, root2, _root3 = roots.map(&:first)
+      assert_no_difference 'root1.descendants.size' do
+        assert_difference 'root2.descendants.size', root1.subtree.size do
+          root1.parent_id = root2.id
+          root1.save!
+        end
+      end
+    end
+  end
+
+  def test_set_parent_id_with_non_default_ancestry_column
+    AncestryTestDatabase.with_model :depth => 3, :width => 3, :ancestry_column => :alternative_ancestry do |model, roots|
+      root1, root2, _root3 = roots.map(&:first)
+      assert_no_difference 'root1.descendants.size' do
+        assert_difference 'root2.descendants.size', root1.subtree.size do
+          root1.parent_id = root2.id
+          root1.save!
+        end
+      end
+    end
+  end
+
   def test_setup_test_nodes
     AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
       assert_equal Array, roots.class


### PR DESCRIPTION
a8e95fa mistakenly replaced a nil check for the new parent ID in the
parent_id setter with a check for `ancestry?`. The setter would then
only set the parent if the model already had ancestors, rather than if
a parent ID had been passed.