### PR TITLE
Added descriptive alias :has_parent? to existing :ancestors? method

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ record:
     path             Scopes model on path records of the record
     children         Scopes the model on children of the record
     child_ids        Returns a list of child ids
+    has_parent?     Returns true if the record has a parent, false otherwise
     has_children?    Returns true if the record has any children, false otherwise
     is_childless?    Returns true is the record has no children, false otherwise
     siblings         Scopes the model on siblings of the record, the record itself is included*

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -87,6 +87,7 @@ module Ancestry
       # ancestor_ids.present?
       read_attribute(self.ancestry_base_class.ancestry_column).present?
     end
+    alias :has_parent? :ancestors?
 
     def ancestry_changed?
       changed.include?(self.ancestry_base_class.ancestry_column.to_s)


### PR DESCRIPTION
I had assumed there was already a `:has_parent?` method, but was surprised to get an error when I tried.
There is an undocumented `:ancestors?` method which checks for a value in the parent field, which is what I was hoping for from a `:has_parent?` method.
This PR aliases the two methods and updates the documentation to describe the alias _only_.