### PR TITLE
Remove duplicate scope :path_of

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -40,7 +40,6 @@ module Ancestry
       # Named scopes
       scope :roots, lambda { where(root_conditions) }
       scope :ancestors_of, lambda { |object| where(ancestor_conditions(object)) }
-      scope :path_of, lambda { |object| where(path_conditions(object)) }
       scope :children_of, lambda { |object| where(child_conditions(object)) }
       scope :descendants_of, lambda { |object| where(descendant_conditions(object)) }
       scope :subtree_of, lambda { |object| where(subtree_conditions(object)) }


### PR DESCRIPTION
This avoids warnings like this:

    Creating scope :path_of. Overwriting existing method MyModel.path_of.