### PR TITLE
Be more surgical about unscoping; only unscope :where

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -307,19 +307,27 @@ module Ancestry
     end
 
     def unscoped_descendants
-      self.ancestry_base_class.unscoped do
-        self.ancestry_base_class.where descendant_conditions
+      unscoped_where do |scope|
+        scope.where descendant_conditions
       end
     end
 
     def unscoped_current_and_previous_ancestors
-      self.ancestry_base_class.unscoped do
-        self.ancestry_base_class.where id: (ancestor_ids + ancestor_ids_was).uniq
+      unscoped_where do |scope|
+        scope.where id: (ancestor_ids + ancestor_ids_was).uniq
       end
     end
 
     def unscoped_find id
-      self.ancestry_base_class.unscoped { self.ancestry_base_class.find(id) }
+      unscoped_where do |scope|
+        scope.find id
+      end
+    end
+
+    def unscoped_where
+      self.ancestry_base_class.unscoped_where do |scope|
+        yield scope
+      end
     end
   end
 end


### PR DESCRIPTION
Related to: https://github.com/swanandp/acts_as_list/pull/265

I’ve been running into deadlocks in my app. In the past I’ve identified
these being caused by `acts_as_list` being too greedy in its unscoping
(removing default order scopes, and thus creating situations where the
table is searched from opposite ends resulting in a deadlock).

Ancestry seems to be doing the same thing. I’ve made a modification
that ensures we only remove the `:where` scope, leaving other scopes
(like `:order`) intact. The tests still pass (locally). I’ve added in a
workaround for Rails 3.2 that doesn’t support this functionality.