### PR TITLE
adding scope for indirect descendants

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ record:
     has_siblings?    Returns true if the record's parent has more than one child
     is_only_child?   Returns true if the record is the only child of its parent
     descendants      Scopes the model on direct and indirect children of the record
-    descendant_ids   Returns a list of a descendant ids
+    descendant_ids   Returns a list of descendant ids
+    indirects        Scopes the model on indirect children of the record
+    indirect_ids     Returns a list of indirect child ids
     subtree          Scopes the model on descendants and itself
     subtree_ids      Returns a list of all ids in the record's subtree
     depth            Return the depth of the node, root nodes are at depth 0
@@ -152,7 +154,8 @@ For convenience, a couple of named scopes are included at the class level:
     roots                   Root nodes
     ancestors_of(node)      Ancestors of node, node can be either a record or an id
     children_of(node)       Children of node, node can be either a record or an id
-    descendants_of(node)    Descendants of node, node can be either a record or an id
+    descendants_of(node)    Descendants of node, node can be either a record or an id  
+    indirects_of(node)      Indirect children of node, node can be either a record or an id
     subtree_of(node)        Subtree of node, node can be either a record or an id
     siblings_of(node)       Siblings of node, node can be either a record or an id
 

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -41,6 +41,7 @@ module Ancestry
       scope :roots, lambda { where(root_conditions) }
       scope :ancestors_of, lambda { |object| where(ancestor_conditions(object)) }
       scope :children_of, lambda { |object| where(child_conditions(object)) }
+      scope :indirects_of, lambda { |object| where(indirect_conditions(object)) }
       scope :descendants_of, lambda { |object| where(descendant_conditions(object)) }
       scope :subtree_of, lambda { |object| where(subtree_conditions(object)) }
       scope :siblings_of, lambda { |object| where(sibling_conditions(object)) }

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -266,6 +266,24 @@ module Ancestry
       ancestor_ids.include?(node.id)
     end
 
+    # Indirects
+
+    def indirect_conditions
+      self.ancestry_base_class.indirect_conditions(self)
+    end
+
+    def indirects depth_options = {}
+      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).where indirect_conditions
+    end
+
+    def indirect_ids depth_options = {}
+      indirects(depth_options).pluck(self.ancestry_base_class.primary_key)
+    end
+
+    def indirect_of?(node)
+      ancestor_ids.include?(node.id)
+    end
+
     # Subtree
 
     def subtree_conditions

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -263,7 +263,7 @@ module Ancestry
     end
 
     def descendant_of?(node)
-      ancestor_ids.include?(node.id)
+      ancestor_ids[0..-2].include?(node.id)
     end
 
     # Indirects

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -263,7 +263,7 @@ module Ancestry
     end
 
     def descendant_of?(node)
-      ancestor_ids[0..-2].include?(node.id)
+      ancestor_ids.include?(node.id)
     end
 
     # Indirects
@@ -281,7 +281,7 @@ module Ancestry
     end
 
     def indirect_of?(node)
-      ancestor_ids.include?(node.id)
+      ancestor_ids[0..-2].include?(node.id)
     end
 
     # Subtree

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -27,6 +27,18 @@ module Ancestry
       t[ancestry_column].eq(node.child_ancestry)
     end
 
+    # indirect = anyone who is a descendant, but not a child
+    def indirect_conditions(object)
+      t = arel_table
+      node = to_node(object)
+      # rails has case sensitive matching.
+      if ActiveRecord::VERSION::MAJOR >= 5
+        t[ancestry_column].matches("#{node.child_ancestry}/%", nil, true)
+      else
+        t[ancestry_column].matches("#{node.child_ancestry}/%")
+      end
+    end
+
     def descendant_conditions(object)
       t = arel_table
       node = to_node(object)

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -16,6 +16,9 @@ class ScopesTest < ActiveSupport::TestCase
         # Assertions for descendants_of named scope
         assert_equal test_node.descendants.to_a, model.descendants_of(test_node).to_a
         assert_equal test_node.descendants.to_a, model.descendants_of(test_node.id).to_a
+        # Assertions for indirects_of named scope
+        assert_equal test_node.indirects.to_a, model.indirects_of(test_node).to_a
+        assert_equal test_node.indirects.to_a, model.indirects_of(test_node.id).to_a
         # Assertions for subtree_of named scope
         assert_equal test_node.subtree.to_a, model.subtree_of(test_node).to_a
         assert_equal test_node.subtree.to_a, model.subtree_of(test_node.id).to_a
@@ -58,6 +61,10 @@ class ScopesTest < ActiveSupport::TestCase
       other_grandchild = model.siblings_of(grandchild).new
       other_grandchild.save!
       assert_equal child, other_grandchild.parent
+
+      another_grandchild = model.indirects_of(node).new
+      another_grandchild.save
+      assert_equal child, grandchild.parent
     end
   end
 


### PR DESCRIPTION
this pull request adds a scope for indirect_descendants, 
e.g. grand_children, and grand_grand_children, etc. but not children

This is useful for cases where you have an org-structure, and you want to distinguish 
direct-reports from indirect-reports further down the org-hierarchy