### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ instead.
 
 Ancestry works fine with STI. Just create a STI inheritance hierarchy and
 build an Ancestry tree from the different classes/models. All Ancestry
-relations that where described above will return nodes of any model type. If
+relations that were described above will return nodes of any model type. If
 you do only want nodes of a specific subclass you'll have to add a condition
 on type for that.
 


### PR DESCRIPTION
Just a minor change of 'where' to 'were'.

On a side note:

How about renaming the heading **Using acts_as_tree instead of has_ancestry** to **Using has_ancestry instead of acts_as_tree**? Or, IMO even better: **Use has_ancestry instead of acts_as_tree**

The current wording had me confused a bit, I was not sure if it was telling me that I should or should not be using acts_as_tree instead of has_ancestry.

PS: Amazing gem :heart: 