### PR TITLE
Correct Internals Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ remove the limitation entirely. Changing it to a text will however decrease
 performance because an index cannot be put on the column in that case.
 
 The materialised path pattern requires Ancestry to use a 'like' condition in
-order to fetch descendants. The wild character (`%`) is on the left of the
+order to fetch descendants. The wild character (`%`) is on the right of the
 query, so indexes should be used.
 
 # Contributing and license


### PR DESCRIPTION
Materialized paths are wild-carded from the right hand side according to the code.

https://github.com/stefankroes/ancestry/blob/master/lib/ancestry/materialized_path.rb#L35

Generally speaking b-tree indexes can only do right-hand side LIKE optimizations, I've listed the postgresql documentation below as an example:

https://www.postgresql.org/docs/9.2/static/indexes-types.html