### PR TITLE
trim object allocations while parsing ancestry col

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -206,5 +206,24 @@ module Ancestry
         yield self.ancestry_base_class.unscope(:where)
       end
     end
+
+    ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze
+    if ActiveSupport::VERSION::STRING < "4.0"
+      def primary_key_is_an_integer?
+        if defined?(@primary_key_is_an_integer)
+          @primary_key_is_an_integer
+        else
+          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(columns_hash[primary_key.to_s].type)
+        end
+      end
+    else
+      def primary_key_is_an_integer?
+        if defined?(@primary_key_is_an_integer)
+          @primary_key_is_an_integer
+        else
+          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key))
+        end
+      end
+    end
   end
 end

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -93,10 +93,6 @@ module Ancestry
       changed.include?(self.ancestry_base_class.ancestry_column.to_s)
     end
 
-    def parse_ancestry_column obj
-      obj.to_s.split('/').map { |id| cast_primary_key(id) }
-    end
-
     def ancestor_ids
       parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
     end
@@ -288,16 +284,10 @@ module Ancestry
 
   private
 
-    def cast_primary_key(key)
-      if [:string, :uuid, :text].include? primary_key_type
-        key
-      else
-        key.to_i
-      end
-    end
-
-    def primary_key_type
-      @primary_key_type ||= column_for_attribute(self.class.primary_key).type
+    def parse_ancestry_column obj
+      obj_ids = obj.to_s.split('/')
+      obj_ids.map!(&:to_i) if self.class.primary_key_is_an_integer?
+      obj_ids
     end
 
     def unscoped_descendants


### PR DESCRIPTION
tested for `#ancestor_ids` (since parsing is main part of that method

value      |      3.0.2|      after| ∆
-----------|-----------|-----------|---
ips        |128,935.154|176,705.314|37%
ips σ      |     20.107|     13.874| :+1:
allocations|         24|         14|42%