### PR TITLE
allow chanied scopes to handle object.id properly

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module ClassMethods
     # Fetch tree node if necessary
     def to_node object
-      if object.is_a?(self.ancestry_base_class) then object else find(object) end
+      if object.is_a?(self.ancestry_base_class) then object else unscoped_where{|scope| scope.find object} end
     end
 
     # Scope on relative depth options

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -29,6 +29,27 @@ class ScopesTest < ActiveSupport::TestCase
     end
   end
 
+  def test_chained_scopes
+    AncestryTestDatabase.with_model :depth => 2, :width => 2 do |model, roots|
+      # before Rails 4.0, the last scope in chained scopes used to ignore earler ones
+      # which resulted in: `Post.active.inactive.to_a` == `Post.inactive.to_a`
+      # https://github.com/rails/rails/commit/cd26b6ae
+      # therefore testing against later AR versions only
+      if ActiveRecord::VERSION::MAJOR >=4
+        roots.each do |root, children|
+          child = children.first
+
+          # the first scope limits the second scope
+          assert_empty model.children_of(root).roots
+          assert_empty model.children_of(root.id).roots
+          # object id in the second scope argument should be found without being affected by the first scope
+          assert_equal model.children_of(root).children_of(root).to_a, model.children_of(root).to_a
+          assert_equal model.children_of(root.id).children_of(root.id).to_a, model.children_of(root.id).to_a
+        end
+      end
+    end
+  end
+
   def test_order_by
     AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
       # not thrilled with this. mac postgres has odd sorting requirements


### PR DESCRIPTION
This is a small fix for #390.

currently, chained scopes as below raises errors:

```ruby
model.where.not(id: root).children_of(root.id)
```

because the latter `children_of(root.id)` (or any other scopes in ancestry) calles `find(root.id)`, which is being executed under the earlier scopes and become equivalent to `find(nil)`.

Tests are added with a few comments on ActiveRecord version dependency of this behavior.