### PR TITLE
Avoid redundant query to DB in subtree_of scope

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -41,7 +41,7 @@ module Ancestry
     def subtree_conditions(object)
       t = arel_table
       node = to_node(object)
-      descendant_conditions(object).or(t[primary_key].eq(node.id))
+      descendant_conditions(node).or(t[primary_key].eq(node.id))
     end
 
     def sibling_conditions(object)


### PR DESCRIPTION
When id, e.g. a number, is provided to `subtree_of` scope, the node record is queried twice: by `to_node` in `subtree_conditions` and then by `to_node` in `descendant_conditions`.

Here simple test:
```ruby
  def test_subtree_of
    AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
      test_node = model.roots.first
      assert_equal test_node.subtree.to_a, model.subtree_of(test_node.id).to_a
    end
  end
```
Logs before fix:
```
...
D, [2018-05-17T22:48:51.253111 #30001] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT  "test_nodes".* FROM "test_nodes" WHERE "test_nodes"."ancestry" IS NULL ORDER BY "test_nodes"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2018-05-17T22:48:51.254579 #30001] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT "test_nodes".* FROM "test_nodes" WHERE (("test_nodes"."ancestry" LIKE '1/%' OR "test_nodes"."ancestry" = '1') OR "test_nodes"."id" = 1)
D, [2018-05-17T22:48:51.255942 #30001] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT  "test_nodes".* FROM "test_nodes" WHERE "test_nodes"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
D, [2018-05-17T22:48:51.256430 #30001] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.0ms)  SELECT  "test_nodes".* FROM "test_nodes" WHERE "test_nodes"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
D, [2018-05-17T22:48:51.256943 #30001] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT "test_nodes".* FROM "test_nodes" WHERE (("test_nodes"."ancestry" LIKE '1/%' OR "test_nodes"."ancestry" = '1') OR "test_nodes"."id" = 1)
...
```
Logs after fix:
```
...
D, [2018-05-17T22:47:27.751076 #29675] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT  "test_nodes".* FROM "test_nodes" WHERE "test_nodes"."ancestry" IS NULL ORDER BY "test_nodes"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2018-05-17T22:47:27.752479 #29675] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT "test_nodes".* FROM "test_nodes" WHERE (("test_nodes"."ancestry" LIKE '1/%' OR "test_nodes"."ancestry" = '1') OR "test_nodes"."id" = 1)
D, [2018-05-17T22:47:27.753780 #29675] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT  "test_nodes".* FROM "test_nodes" WHERE "test_nodes"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
D, [2018-05-17T22:47:27.754275 #29675] DEBUG -- :   AncestryTestDatabase::TestSubtreeOfTestNode Load (0.1ms)  SELECT "test_nodes".* FROM "test_nodes" WHERE (("test_nodes"."ancestry" LIKE '1/%' OR "test_nodes"."ancestry" = '1') OR "test_nodes"."id" = 1)
...
```