### PR TITLE
remove deprecation warnings

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -1,5 +1,7 @@
 module Ancestry
   module InstanceMethods
+    BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save' : '_was'
+
     # Validate that the ancestors don't include itself
     def ancestry_exclude_self
       errors.add(:base, "#{self.class.name.humanize} cannot be a descendant of itself.") if ancestor_ids.include? self.id
@@ -82,7 +84,11 @@ module Ancestry
       # New records cannot have children
       raise Ancestry::AncestryException.new('No child ancestry for new record. Save record before performing tree operations.') if new_record?
 
-      if self.send("#{self.ancestry_base_class.ancestry_column}_was").blank? then id.to_s else "#{self.send "#{self.ancestry_base_class.ancestry_column}_was"}/#{id}" end
+      if self.send("#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}").blank?
+        id.to_s
+      else
+        "#{self.send "#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}"}/#{id}"
+      end
     end
 
     # Ancestors
@@ -119,14 +125,8 @@ module Ancestry
       parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}_was"))
     end
 
-    if ActiveRecord::VERSION::STRING >= '5.1.0'
-      def ancestor_ids_before_last_save
-        parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}_before_last_save"))
-      end
-    else
-      def ancestor_ids_before_last_save
-        parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}_was"))
-      end
+    def ancestor_ids_before_last_save
+      parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}"))
     end
 
     def path_ids

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -1,6 +1,7 @@
 module Ancestry
   module InstanceMethods
     BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save' : '_was'
+    IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database' : '_was'
 
     # Validate that the ancestors don't include itself
     def ancestry_exclude_self
@@ -84,10 +85,10 @@ module Ancestry
       # New records cannot have children
       raise Ancestry::AncestryException.new('No child ancestry for new record. Save record before performing tree operations.') if new_record?
 
-      if self.send("#{self.ancestry_base_class.ancestry_column}_in_database").blank?
+      if self.send("#{self.ancestry_base_class.ancestry_column}#{IN_DATABASE_SUFFIX}").blank?
         id.to_s
       else
-        "#{self.send "#{self.ancestry_base_class.ancestry_column}_in_database"}/#{id}"
+        "#{self.send "#{self.ancestry_base_class.ancestry_column}#{IN_DATABASE_SUFFIX}"}/#{id}"
       end
     end
 

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -84,10 +84,10 @@ module Ancestry
       # New records cannot have children
       raise Ancestry::AncestryException.new('No child ancestry for new record. Save record before performing tree operations.') if new_record?
 
-      if self.send("#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}").blank?
+      if self.send("#{self.ancestry_base_class.ancestry_column}_in_database").blank?
         id.to_s
       else
-        "#{self.send "#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}"}/#{id}"
+        "#{self.send "#{self.ancestry_base_class.ancestry_column}_in_database"}/#{id}"
       end
     end
 


### PR DESCRIPTION
Re: Issue #372.

The previous PR left a usage of a deprecated method in place in the `child_ancestry` method.  This PR  removes it for AR >= 5.1.0.

This PR was closed and reopened to re-trigger a Travis build timeout.

### Update: 
`attribute_before_last_save` seems to have slightly different behavior than `attribute_was`, which led to test failures.  Replaced usages with `attribute_in_database`, which is a supported [method alias](http://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html#method-i-attribute_in_database) for `attribute_was`.