### PR TITLE
Fix primary_key integer check

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -208,22 +208,16 @@ module Ancestry
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze
-    if ActiveSupport::VERSION::STRING < "4.0"
-      def primary_key_is_an_integer?
-        if defined?(@primary_key_is_an_integer)
-          @primary_key_is_an_integer
-        else
-          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(columns_hash[primary_key.to_s].type)
-        end
+    def primary_key_is_an_integer?
+      if defined?(@primary_key_is_an_integer)
+        @primary_key_is_an_integer
+      else
+        @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(primary_key_type)
       end
-    else
-      def primary_key_is_an_integer?
-        if defined?(@primary_key_is_an_integer)
-          @primary_key_is_an_integer
-        else
-          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key))
-        end
-      end
+    end
+
+    def primary_key_type
+      (ActiveSupport::VERSION::STRING < '4.0' ? columns_hash[primary_key.to_s] : type_for_attribute(primary_key)).type
     end
   end
 end

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -123,4 +123,16 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_primary_key_is_an_integer
+    AncestryTestDatabase.with_model(extra_columns: { string_id: :string }) do |model|
+      model.primary_key = :string_id
+
+      assert !model.primary_key_is_an_integer?
+    end
+
+    AncestryTestDatabase.with_model do |model|
+      assert model.primary_key_is_an_integer?
+    end
+  end
 end


### PR DESCRIPTION
The latest release (3.0.3) has broken our code, because of https://github.com/stefankroes/ancestry/pull/386/.

The issue is the following:

```
pry:1> ActiveSupport::VERSION::STRING
=> "4.2.8"
pry:1> self.class.type_for_attribute(self.class.primary_key)
=> #<ActiveRecord::Type::String:0x007ffac181f628 @limit=24, @precision=nil, @scale=nil>
pry:1> self.class.primary_key_is_an_integer?
=> true
pry:1> self.id
=> "5bd1da2c4624b83bd51e40af"
pry:1> self.id.to_i
=> 5
```

Because of the ActiveSupport version, it uses the `type_for_attribute` function which returns with an `ActiveRecord::Type::String` instance which is not included in the `ANCESTRY_UNCAST_TYPES` array. What included is the `type` of this instance.

```
[78] pry:1> self.class.type_for_attribute(self.class.primary_key).type
=> :string
```