### PR TITLE
Fix primary_key integer check

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -221,7 +221,7 @@ module Ancestry
         if defined?(@primary_key_is_an_integer)
           @primary_key_is_an_integer
         else
-          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key))
+          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key).type)
         end
       end
     end

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -123,4 +123,16 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_primary_key_is_an_integer
+    AncestryTestDatabase.with_model(extra_columns: { string_id: :string }) do |model|
+      model.primary_key = :string_id
+
+      assert !model.primary_key_is_an_integer?
+    end
+
+    AncestryTestDatabase.with_model do |model|
+      assert model.primary_key_is_an_integer?
+    end
+  end
 end


### PR DESCRIPTION
This is basically code from #412

This fixes a bug in Active record > 4.0 for detecting integer columns

I just minimized the number of lines that needed to be changed

Thanks @adam101