### PR TITLE
Make arrange_nodes more memory efficient

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -62,6 +62,20 @@ module Ancestry
       end
     end
 
+    # convert a hash of the form {node => children} to an array of nodes, child first
+    # modifies input hash
+    #
+    # @param arranged [Hash{Node => {Node => {}, Node => {}}}] arranged nodes
+    # @returns [Array[Node]] array of nodes with the parent before the children
+    def flatten_arranged_nodes(arranged)
+      arranged.inject([]) do |sorted_nodes, pair|
+        node, children = pair
+        sorted_nodes << node
+        sorted_nodes += flatten_arranged_nodes(children) unless children.blank?
+        sorted_nodes
+      end
+    end
+
      # Arrangement to nested array for serialization
      # You can also supply your own serialization logic using blocks
      # also allows you to pass the order just as you can pass it to the arrange method
@@ -105,12 +119,7 @@ module Ancestry
         arranged = arrange_nodes(presorted_nodes)
       end
 
-      arranged.inject([]) do |sorted_nodes, pair|
-        node, children = pair
-        sorted_nodes << node
-        sorted_nodes += sort_by_ancestry(children, &block) unless children.blank?
-        sorted_nodes
-      end
+      flatten_arranged_nodes(arranged)
     end
 
     # Integrity checking

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -63,17 +63,15 @@ module Ancestry
     end
 
     # convert a hash of the form {node => children} to an array of nodes, child first
-    # modifies input hash
     #
     # @param arranged [Hash{Node => {Node => {}, Node => {}}}] arranged nodes
     # @returns [Array[Node]] array of nodes with the parent before the children
-    def flatten_arranged_nodes(arranged)
-      arranged.inject([]) do |sorted_nodes, pair|
-        node, children = pair
-        sorted_nodes << node
-        sorted_nodes += flatten_arranged_nodes(children) unless children.blank?
-        sorted_nodes
+    def flatten_arranged_nodes(arranged, nodes = [])
+      arranged.each do |node, children|
+        nodes << node
+        flatten_arranged_nodes(children, nodes) unless children.empty?
       end
+      nodes
     end
 
      # Arrangement to nested array for serialization


### PR DESCRIPTION
Resurrecting this old PR

The main work was pulled out to a few prs:

- [x] #417 
- [x] #418 
- [x] #419 
- [x] #425
- [x] #613

When this PR started, hashes had an indeterminant order. So it was tricky to arrange these in a hash and have a consistent output order.

When a sorting block is not provided, the current goal is to have the output match the input order as closely as possible, just with the parent nodes coming before the children nodes.

This is working well, even when partial trees are provide with missing nodes. There are a few issues when the parent nodes are necessary to determine a proper order, but this is really only necessary when a sorting block is provided. As far as I'm concerned, we should be sorting in sql (using `arranged_by_ancestry(additional, columns)`) and not using a ruby block.

So the only remaining work left in this PR is fixing the code that converts from an arranged tree back to an array. This creates too many array objects. Thanks to the suggestions from @estepnv I was able to reduce the number of arrays and remove the recursive calls.

---

For future me:


FUTURE: This has me wondering if we want to convert most of the recursive calls to linear ones across the codebase. Using an explicit stack instead of the call stack. Would need to run a few benchmarks to determine if it actually saved us that much memory. I can't imagine that a depth of 100 would blow this out of memory if we cut down on the temporary arrays created at each level.

~~FUTURE: Now that we have nailed down the sort order for canonical using binary columns / C sorting, we probably want to remove the ambiguous sorting and ensure the STRICT cases work. The `CORRECT` cases will probably never be implemented.~~ DONE

FUTURE: Do we want to enforce that this is called with `ordered_by_ancestry_and(fields)` and not `order(fields)`? I do like the way the sorting works for the `&block` case and it would be nice to get that into sql. Maybe make the case `named_ancestry = ancestry.map(&:name).join('/')` or `ranked_ancestry = `ancestry.map(&:rank).join('/')`