### PR TITLE
arrange no longer clears order in default scope

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -27,10 +27,13 @@ module Ancestry
       end
     end
 
-    # Arrangement
+    # Get all nodes and sorting them into an empty hash
     def arrange options = {}
-      # Get all nodes ordered by ancestry and start sorting them into an empty hash
-      arrange_nodes self.ancestry_base_class.reorder(options.delete(:order)).where(options)
+      if (order = options.delete(:order))
+        arrange_nodes self.ancestry_base_class.order(order).where(options)
+      else
+        arrange_nodes self.ancestry_base_class.where(options)
+      end
     end
 
     # Arrange array of nodes into a nested hash of the form


### PR DESCRIPTION
This was introduced by #320
This was pulled out of #415 

I don't like having `reorder(nil)` when no order was specified (which clears the original ordering)
Probably no one will see this bug as it will only be seen if a default scope has an order in it

Just a nit, but there it is