### PR TITLE
Don't drop parentless nodes

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -38,22 +38,16 @@ module Ancestry
 
     # Arrange array of nodes into a nested hash of the form
     # {node => children}, where children = {} if the node has no children
+    # If a node's parent is not included, the node will be included as if it is a top level node
     def arrange_nodes(nodes)
-      arranged = ActiveSupport::OrderedHash.new
-      nodes_ids = nodes.map(&:id)
-      min_depth = nodes.map(&:depth).min
-      index = Hash.new { |h, k| h[k] = ActiveSupport::OrderedHash.new }
+      node_ids = Set.new(nodes.map(&:id))
+      index = Hash.new { |h, k| h[k] = {} }
 
-      nodes.each do |node|
+      nodes.each_with_object({}) do |node, arranged|
         children = index[node.id]
         index[node.parent_id][node] = children
-
-        if node.depth == min_depth || !nodes_ids.include?(node.parent_id)
-          arranged[node] = children
-        end
+        arranged[node] = children unless node_ids.include?(node.parent_id)
       end
-
-      arranged
     end
 
      # Arrangement to nested array

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -40,19 +40,17 @@ module Ancestry
     # {node => children}, where children = {} if the node has no children
     def arrange_nodes(nodes)
       arranged = ActiveSupport::OrderedHash.new
-      min_depth = Float::INFINITY
+      nodes_ids = nodes.map(&:id)
+      min_depth = nodes.map(&:depth).min
       index = Hash.new { |h, k| h[k] = ActiveSupport::OrderedHash.new }
 
       nodes.each do |node|
         children = index[node.id]
         index[node.parent_id][node] = children
 
-        depth = node.depth
-        if depth < min_depth
-          min_depth = depth
-          arranged.clear
+        if node.depth == min_depth || !nodes_ids.include?(node.parent_id)
+          arranged[node] = children
         end
-        arranged[node] = children if depth == min_depth
       end
 
       arranged

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -202,8 +202,7 @@ class ArrangementTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: don't drop parentless nodes
-  def xtest_arrange_partial
+  def test_arrange_partial
     AncestryTestDatabase.with_model do |model|
       # - n1
       #   - n2

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -202,7 +202,7 @@ class ArrangementTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: arrange_nodes broken, dropping some parentless nodes
+  # TODO: don't drop parentless nodes
   def xtest_arrange_partial
     AncestryTestDatabase.with_model do |model|
       # - n1
@@ -216,8 +216,7 @@ class ArrangementTest < ActiveSupport::TestCase
       n4 = model.create!(parent: n2)
       n5 = model.create!(parent: n1)
       assert_equal({n5 => {}, n3 => {}}, model.arrange_nodes([n5, n3]))
-      # ensure n5 comes before n3 in the ordered hash
-      assert_equal(n5.id, model.arrange_nodes([n5, n3]).keys.first.id)
+      assert_equal([n5.id, n3.id], model.arrange_nodes([n5, n3]).keys.map(&:id))
     end
   end
 end

--- a/test/concerns/sort_by_ancestry_test.rb
+++ b/test/concerns/sort_by_ancestry_test.rb
@@ -48,8 +48,7 @@ class SortByAncestryTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: don't drop parentless nodes
-  def xtest_sort_by_ancestry_no_parents_same_level
+  def test_sort_by_ancestry_no_parents_same_level
     AncestryTestDatabase.with_model do |model|
       n1, n2, n3, n4, n5, n6 = build_tree(model)
 
@@ -65,8 +64,7 @@ class SortByAncestryTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: don't drop parentless nodes
-  def xtest_sort_by_ancestry_missing_parent_middle_of_tree
+  def test_sort_by_ancestry_missing_parent_middle_of_tree
     AncestryTestDatabase.with_model do |model|
       n1, n2, n3, n4, n5, n6 = build_tree(model)
 
@@ -149,10 +147,9 @@ class SortByAncestryTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: don't drop parentless nodes
   # TODO: nodes need to follow original ordering
   # NOTE: even for partial trees, if the input records are ranked, the output works
-  def xtest_sort_by_ancestry_with_sql_sort_paginated_missing_parents_and_children
+  def test_sort_by_ancestry_with_sql_sort_paginated_missing_parents_and_children
     AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
 
@@ -167,10 +164,8 @@ class SortByAncestryTest < ActiveSupport::TestCase
 
   # in a perfect world, the second case would be matched
   # but since presorting is not used, the best we can assume from input order is that n1 > n2
-  # TODO: don't drop parentless nodes
-  # TODO: follow input order
   # TODO: find a way to rank missing nodes
-  def xtest_sort_by_ancestry_with_block_paginated_missing_parents_and_children
+  def test_sort_by_ancestry_with_block_paginated_missing_parents_and_children
     AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
       sort = -> (a, b) { a.rank <=> b.rank }

--- a/test/concerns/sort_by_ancestry_test.rb
+++ b/test/concerns/sort_by_ancestry_test.rb
@@ -1,6 +1,13 @@
 require_relative '../environment'
 
 class SortByAncestryTest < ActiveSupport::TestCase
+  # in a perfect world, we'd only follow the CORRECT=true case
+  # but when not enough information is available, the STRICT=true case is good enough
+  #
+  # these flags are to allow multiple values for correct for tests
+  CORRECT = (ENV["CORRECT"] == "true")
+  STRICT = (ENV["STRICT"] == "true")
+
   # tree is of the form:
   #   - n1
   #     - n2
@@ -41,6 +48,7 @@ class SortByAncestryTest < ActiveSupport::TestCase
     end
   end
 
+  # TODO: don't drop parentless nodes
   def xtest_sort_by_ancestry_no_parents_same_level
     AncestryTestDatabase.with_model do |model|
       n1, n2, n3, n4, n5, n6 = build_tree(model)
@@ -57,11 +65,17 @@ class SortByAncestryTest < ActiveSupport::TestCase
     end
   end
 
+  # TODO: don't drop parentless nodes
   def xtest_sort_by_ancestry_missing_parent_middle_of_tree
     AncestryTestDatabase.with_model do |model|
       n1, n2, n3, n4, n5, n6 = build_tree(model)
 
-      assert_equal [n1, n5, n4].map(&:id), model.sort_by_ancestry([n5, n4, n1]).map(&:id)
+      records = model.sort_by_ancestry([n5, n4, n1])
+      if (!CORRECT) && (STRICT || records[1] == n5)
+        assert_equal [n1, n5, n4].map(&:id), records.map(&:id)
+      else
+        assert_equal [n1, n4, n5].map(&:id), records.map(&:id)
+      end
     end
   end
 
@@ -93,7 +107,17 @@ class SortByAncestryTest < ActiveSupport::TestCase
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
       sort = -> (a, b) { a.rank <=> b.rank }
 
-      records = model.sort_by_ancestry(model.all.order(:rank).reverse, &sort)
+      records = model.sort_by_ancestry(model.all.order(:id).reverse, &sort)
+      assert_equal [n1, n5, n3, n2, n4, n6].map(&:id), records.map(&:id)
+    end
+  end
+
+  # NOTE: if the sql orders the records, no sorting block is necessary
+  def test_sort_by_ancestry_with_block_full_tree_sql_sort
+    AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
+      n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
+
+      records = model.sort_by_ancestry(model.all.order(:rank))
       assert_equal [n1, n5, n3, n2, n4, n6].map(&:id), records.map(&:id)
     end
   end
@@ -103,39 +127,60 @@ class SortByAncestryTest < ActiveSupport::TestCase
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
       sort = -> (a, b) { a.rank <=> b.rank }
 
-      assert_equal [n1, n5, n2].map(&:id), model.sort_by_ancestry([n2, n1, n5], &sort).map(&:id)
+      assert_equal [n1, n5, n2].map(&:id), model.sort_by_ancestry([n1, n2, n5], &sort).map(&:id)
     end
   end
 
+  # seems the best we can do is to have [5,3] + [4,6]
+  # if we follow input order, we can end up with either result
+  # a) n3 moves all the way to the right or b) n5 moves all the way to the left
+  # TODO: find a way to rank missing nodes
   def test_sort_by_ancestry_with_block_no_parents_all_children
     AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
       sort = -> (a, b) { a.rank <=> b.rank }
 
-      assert_equal [n5, n3, n4, n6].map(&:id), model.sort_by_ancestry([n3, n4, n5, n6], &sort).map(&:id)
+      records = model.sort_by_ancestry([n3, n4, n5, n6], &sort)
+      if CORRECT || records[0] == n5
+        assert_equal [n5, n3, n4, n6].map(&:id), records.map(&:id)
+      else
+        assert_equal [n4, n6, n5, n3].map(&:id), records.map(&:id)
+      end
     end
   end
 
-  # NOTE: this is non ranked. included to compare and contrast with ranked version
-  # TODO: arrange_nodes broken, dropping some parentless nodes
-  def xtest_sort_by_ancestry_paginated_missing_parents_and_children
+  # TODO: don't drop parentless nodes
+  # TODO: nodes need to follow original ordering
+  # NOTE: even for partial trees, if the input records are ranked, the output works
+  def xtest_sort_by_ancestry_with_sql_sort_paginated_missing_parents_and_children
     AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
-      sort = -> (a, b) { a.rank <=> b.rank }
 
-      records = model.sort_by_ancestry(model.all.order(:rank).reverse)
-      assert_equal [n3, n2, n4].map(&:id), model.sort_by_ancestry([n3, n2, n4]).map(&:id)
+      records = model.sort_by_ancestry([n2, n4, n3])
+      if (!CORRECT) && (STRICT || records[0] == n2)
+        assert_equal [n2, n4, n3].map(&:id), records.map(&:id)
+      else
+        assert_equal [n3, n2, n4].map(&:id), records.map(&:id)
+      end
     end
   end
 
-  # TODO: arrange_nodes broken, dropping some parentless nodes
+  # in a perfect world, the second case would be matched
+  # but since presorting is not used, the best we can assume from input order is that n1 > n2
+  # TODO: don't drop parentless nodes
+  # TODO: follow input order
+  # TODO: find a way to rank missing nodes
   def xtest_sort_by_ancestry_with_block_paginated_missing_parents_and_children
     AncestryTestDatabase.with_model :extra_columns => {:rank => :integer} do |model|
       n1, n2, n3, n4, n5, n6 = build_ranked_tree(model)
       sort = -> (a, b) { a.rank <=> b.rank }
 
-      records = model.sort_by_ancestry(model.all.order(:rank).reverse, &sort)
-      assert_equal [n3, n2, n4].map(&:id), model.sort_by_ancestry([n3, n2, n4], &sort).map(&:id)
+      records = model.sort_by_ancestry([n2, n4, n3], &sort)
+      if (!CORRECT) && (STRICT || records[0] == n2)
+        assert_equal [n2, n4, n3].map(&:id), records.map(&:id)
+      else
+        assert_equal [n3, n2, n4].map(&:id), records.map(&:id)
+      end
     end
   end
 end


### PR DESCRIPTION
Extracted from #415 

Fixes #411
Fixes #362

`arrange_nodes` no longer drops child nodes. thanks @trafium

@Fryguy Think this is the simplified version of 415 that you wanted


We also now have other tests showing what other work needs to be done
