### PR TITLE
Tune parse_ancestry_column

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -320,11 +320,12 @@ module Ancestry
     end
 
   private
+    ANCESTRY_DELIMITER = '/'.freeze
 
     def parse_ancestry_column obj
-      obj_ids = obj.to_s.split('/')
-      obj_ids.map!(&:to_i) if self.class.primary_key_is_an_integer?
-      obj_ids
+      return [] unless obj
+      obj_ids = obj.split(ANCESTRY_DELIMITER)
+      self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
     end
 
     def unscoped_descendants


### PR DESCRIPTION
moving across an old patch from @NickLaMuro
with minor tweaks of course (nor sure if frown or smiley goes here)

Most of the win was from avoiding the `nil.to_s` which creates an extra string object for the root node.

```ruby
obj.depth == 5
root.depth == 0
```

### ips

 label               | 3.0.4                 | 3.0.4.pr
---------------------|-----------------------|---------------
 `obj.ancestor_ids`  | 225,589.1 i/s         | 220,407.1 i/s
 `root.ancestor_ids` | 317,390.0 i/s - 1.10x | 349,432.7 i/s

### memsize

 label               | 3.0.4              | 3.0.4.pr
---------------------|--------------------|------------
 `obj.ancestor_ids`  | 520.0 objs - 1.08x | 480.0 objs
 `root.ancestor_ids` | 200.0 objs - 1.67x | 120.0 objs

### objects

 label               | 3.0.4            | 3.0.4.pr
---------------------|------------------|----------
 `obj.ancestor_ids`  | 9.0 objs - 1.12x | 8.0 objs
 `root.ancestor_ids` | 5.0 objs - 1.67x | 3.0 objs
