### PR TITLE
Do not hit the database for empty ancestries

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -151,6 +151,7 @@ module Ancestry
     end
 
     def ancestors depth_options = {}
+      return self.ancestry_base_class.none unless ancestors?
       self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.where ancestor_conditions
     end
 


### PR DESCRIPTION
When doing `object.ancestors`, there is a hit to the database even if the ancestry is empty:

    Area Load (0.4ms)  SELECT "areas".* FROM "areas" WHERE 1=0 ORDER BY COALESCE("areas"."ancestry", '') ASC

ActiveRecord [since 4.0](https://github.com/rails/rails/commit/8270e4a8ce8337fca98030953922e5992b06a3dd) provides an interface to return empty queries that don't hit the database.
Let's return that when there is no ancestry to load.
