### PR TITLE
Minor update to which versions of Rails are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ records.
 
 NOTE:
 
-- Ancestry 3.x supports Rails 5.0 and earlier.
+- Ancestry 2.x supports Rails 4.1, and earlier
+- Ancestry 3.x supports Rails 5.0, and 4.2
 - Ancestry 4.0 only supports rails 5.0 and higher
 
 # Installation


### PR DESCRIPTION
Our team is going though the process of upgrading Rails and ran into the issue that type_for_attribute was undefined. After some investigation, we found that type_for_attribute was added in Rails 4.2 and was not defined previously.