### PR TITLE
WIP - Fix rails 5.1.6 deprecation on changed.

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -139,7 +139,11 @@ module Ancestry
     alias :has_parent? :ancestors?
 
     def ancestry_changed?
-      changed.include?(self.ancestry_base_class.ancestry_column.to_s)
+      if ActiveRecord::VERSION::STRING >= '5.1.0'
+        will_save_change_to_attribute?(self.ancestry_base_class.ancestry_column.to_s)
+      else
+        changed.include?(self.ancestry_base_class.ancestry_column.to_s)
+      end
     end
 
     def ancestor_ids


### PR DESCRIPTION
Fixes rails 5.1.6 deprecation:

DEPRECATION WARNING: The behavior of `changed_attributes` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_changes.transform_values(&:first)` instead. (called from ancestry_changed? at .../2.5.0/gems/ancestry-3.0.5/lib/ancestry/instance_methods.rb:104)