### PR TITLE
[ISSUE-481] uses the new version of primary_key_is_an_integer? only on 4.2+

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -203,7 +203,7 @@ module Ancestry
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze
-    if ActiveSupport::VERSION::STRING < "4.0"
+    if ActiveSupport::VERSION::STRING < "4.2"
       def primary_key_is_an_integer?
         if defined?(@primary_key_is_an_integer)
           @primary_key_is_an_integer


### PR DESCRIPTION
Note, I don't really know how to proceed for testing here as this is only fixing issue outside of the versions in the `travis.yml` 

I have tested this on a local project

Fixes https://github.com/stefankroes/ancestry/pull/439