### PR TITLE
Use new shiny rails 5.1 methods to detect changes

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -139,7 +139,14 @@ module Ancestry
     alias :has_parent? :ancestors?
 
     def ancestry_changed?
-      changed.include?(self.ancestry_base_class.ancestry_column.to_s)
+      column = self.ancestry_base_class.ancestry_column.to_s
+      if ActiveRecord::VERSION::STRING >= '5.1.0'
+        # These methods return nil if there are no changes.
+        # This was fixed in a refactoring in rails 6.0: https://github.com/rails/rails/pull/35933
+        !!(will_save_change_to_attribute?(column) || saved_change_to_attribute?(column))
+      else
+        changed.include?(column)
+      end
     end
 
     def ancestor_ids

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -30,4 +30,46 @@ class ArrangementTest < ActiveSupport::TestCase
       assert_equal("parent/grandchild", m3.name_path)
     end
   end
+
+  def test_has_ancestry_detects_changes_in_after_save
+    AncestryTestDatabase.with_model(:extra_columns => {:name => :string, :name_path => :string}) do |model|
+      model.class_eval do
+        after_save :after_hook
+        attr_reader :modified
+
+        def after_hook
+          @modified = ancestry_changed?
+          nil
+        end
+      end
+
+      m1 = model.create!(:name => "parent")
+      m2 = model.create!(:parent => m1, :name => "child")
+      m2.parent = nil
+      m2.save!
+      assert_equal(false, m1.modified)
+      assert_equal(true, m2.modified)
+    end
+  end
+
+  def test_has_ancestry_detects_changes_in_before_save
+    AncestryTestDatabase.with_model(:extra_columns => {:name => :string, :name_path => :string}) do |model|
+      model.class_eval do
+        before_save :before_hook
+        attr_reader :modified
+
+        def before_hook
+          @modified = ancestry_changed?
+          nil
+        end
+      end
+
+      m1 = model.create!(:name => "parent")
+      m2 = model.create!(:parent => m1, :name => "child")
+      m2.parent = nil
+      m2.save!
+      assert_equal(false, m1.modified)
+      assert_equal(true, m2.modified)
+    end
+  end
 end


### PR DESCRIPTION
Fixes a deprecation warning if an after callback tries to call
ancestry_changed?

Note, the !! is required because rails 5.1 and 5.2 return nil in these
methods if they have no changes.  This was fixed in a refactoring in rails 6.0:
rails/rails#35933

Replaces #434 