### PR TITLE
Update codebase to remove Rails 6 deprecation warnings

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -202,7 +202,7 @@ module Ancestry
           yield self.ancestry_base_class
         end
       else
-        yield self.ancestry_base_class.unscope(:where)
+        yield self.ancestry_base_class.unscoped
       end
     end
 


### PR DESCRIPTION
Hey! We're planning on upgrading to Rails 6.0.0.rc1 soon. I traced a number of deprecation warnings back to `ancestry`

These include using `update_attributes` over `update` as well as using class level querying methods if the receiver scope has leaked (see https://github.com/rails/rails/pull/35280)

One thing I am not 100% sure about is using `unscoped` over `unscope(:where)`. Feedback would be appreciated on this. 