### PR TITLE
Fix error when ancestry field is integer

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -377,7 +377,7 @@ module Ancestry
 
     def parse_ancestry_column obj
       return [] unless obj
-      obj_ids = obj.split(ANCESTRY_DELIMITER)
+      obj_ids = obj.to_s.split(ANCESTRY_DELIMITER)
       self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
     end
 


### PR DESCRIPTION
- Problem
When the field field ancestry is an integer on database the method
`parse_ancestry_column` raise error because of split is not a method
of integer

- Solution
Return the method `to_s` on the method `parse_ancestry_column` to change
integer to string before do the split

- Error Log

```
NoMethodError:
        undefined method `split' for 13654:Fixnum
      # /home/klaus/.rvm/gems/ruby-2.3.1/gems/ancestry-3.0.7/lib/ancestry/instance_methods.rb:381:in `parse_ancestry_column'
      # /home/klaus/.rvm/gems/ruby-2.3.1/gems/ancestry-3.0.7/lib/ancestry/instance_methods.rb:153:in `ancestor_ids'
```

- Issue: #446