### PR TITLE
Allow string ids

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -6,5 +6,5 @@ require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A\w+(\/\w+)*\Z/
+  ANCESTRY_PATTERN = /\A[\w\-]+(\/[\w\-]+)*\Z/
 end

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -6,5 +6,6 @@ require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+  # ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
+  ANCESTRY_PATTERN = /\A\w+(\/\w+)*\Z/
 end

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -6,6 +6,5 @@ require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
 
 module Ancestry
-  # ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
   ANCESTRY_PATTERN = /\A\w+(\/\w+)*\Z/
 end

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module ClassMethods
     # Fetch tree node if necessary
     def to_node object
-      if object.is_a?(self.ancestry_base_class) then object else unscoped_where{|scope| scope.find object} end
+      if object.is_a?(self.ancestry_base_class) then object else unscoped_where{|scope| scope.find object.id} end
     end
 
     # Scope on relative depth options

--- a/test/concerns/integrity_checking_and_restoration_test.rb
+++ b/test/concerns/integrity_checking_and_restoration_test.rb
@@ -12,7 +12,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
 
     AncestryTestDatabase.with_model :width => 3, :depth => 3 do |model, roots|
       # Check detection of invalid format for ancestry column
-      roots.first.first.update_attribute model.ancestry_column, 'invalid_ancestry'
+      roots.first.first.update_attribute model.ancestry_column, 'invalid ancestry'
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -4,11 +4,11 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation
     AncestryTestDatabase.with_model do |model|
       node = model.create
-      ['3', '10/2', '1/4/30', nil].each do |value|
+      ['3', 'A', '10/2', '1/4/30', 'a/b', 'ID_1/ID_2/ID_3', nil].each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
-      ['1/3/', '/2/3', 'a', 'a/b', '-34', '/54'].each do |value|
+      ['1/3/', '/2/3', '-34', '/54'].each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert !node.errors[model.ancestry_column].blank?
       end


### PR DESCRIPTION
There were tries in the past to implement this feature but way to complicated through different issues and PRs. No idea why you would limit the regex to just integer ids in the beginning. But all the other solutions bloat the code to achieve a simple functionality.

#254 #262 #265 

This PR would make it possible to drop the option `primary_key_format` for the majority of cases that don't use integer ids. It still could be required if someone uses special characters for ids (no idea if this is even possible). If there is no reason against the changing the regex I suggest roll this simple solution.

Addtionally `primary_key_format` is documented in the readme but not reflected in the code.