### PR TITLE
fix :primary_key_format

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -6,5 +6,4 @@ require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
 
 module Ancestry
-  ANCESTRY_PATTERN = /\A[0-9]+(\/[0-9]+)*\Z/
 end

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -4,7 +4,6 @@ module Ancestry
     IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database' : '_was'
 
     def self.extended(base)
-      base.validates_format_of base.ancestry_column, :with => Ancestry::ANCESTRY_PATTERN, :allow_nil => true
       base.send(:include, InstanceMethods)
     end
 

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -71,7 +71,7 @@ module Ancestry
       # Validates the ancestry, but can also be applied if validation is bypassed to determine if children should be affected
       def sane_ancestry?
         ancestry_value = read_attribute(self.ancestry_base_class.ancestry_column)
-        ancestry_value.nil? || (ancestry_value.to_s =~ Ancestry::ANCESTRY_PATTERN && !ancestor_ids.include?(self.id))
+        (ancestry_value.nil? || !ancestor_ids.include?(self.id)) && valid?
       end
 
       # optimization - better to go directly to column and avoid parsing

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -15,6 +15,34 @@ class ValidationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_ancestry_column_validation_alt
+    AncestryTestDatabase.with_model(:primary_key_format => /[a-z]+/) do |model|
+      node = model.create
+      ['a', 'a/b', 'a/b/c', nil].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert node.errors[model.ancestry_column].blank?
+      end
+      ['1', '1/2', 'a/b/', '/a/b'].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert !node.errors[model.ancestry_column].blank?
+      end
+    end
+  end
+
+  def test_ancestry_column_validation_full_key
+    AncestryTestDatabase.with_model(:primary_key_format => /\A[a-z]+(\/[a-z]+)*\Z/) do |model|
+      node = model.create
+      ['a', 'a/b', 'a/b/c', nil].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert node.errors[model.ancestry_column].blank?
+      end
+      ['1', '1/2', 'a/b/', '/a/b'].each do |value|
+        node.send :write_attribute, model.ancestry_column, value
+        node.valid?; assert !node.errors[model.ancestry_column].blank?
+      end
+    end
+  end
+
   def test_validate_ancestry_exclude_self
     AncestryTestDatabase.with_model do |model|
       parent = model.create!


### PR DESCRIPTION
Thanks for all the feed back all
And sorry for taking so many years to get this in

This should make it easier for developers to support the various schemes

I'm tempted to completely remove this field, but this solution looked simple enough.

Was tempted to auto derive the field but it connects to the database at class definition time, so thew that away (I'll add the code as reference in a comment for archival purposes)

In the documentation, the delimiter is not specified. But since a few schemes want to specify the delimiter (ltree), I wanted that to be an option. (probably should be doing that when I actually need it... sorry)


fix #221 and #241

See also #132 #262 #265 