### PR TITLE
Move conditionals to MaterializedPath

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -37,27 +37,6 @@ module Ancestry
       # Validate that the ancestor ids don't include own id
       validate :ancestry_exclude_self
 
-      # Named scopes
-      scope :roots, lambda { where(root_conditions) }
-      scope :ancestors_of, lambda { |object| where(ancestor_conditions(object)) }
-      scope :children_of, lambda { |object| where(child_conditions(object)) }
-      scope :indirects_of, lambda { |object| where(indirect_conditions(object)) }
-      scope :descendants_of, lambda { |object| where(descendant_conditions(object)) }
-      scope :subtree_of, lambda { |object| where(subtree_conditions(object)) }
-      scope :siblings_of, lambda { |object| where(sibling_conditions(object)) }
-      scope :ordered_by_ancestry, Proc.new { |order|
-        if %w(mysql mysql2 sqlite sqlite3 postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
-          reorder(
-            Arel::Nodes::Ascending.new(Arel::Nodes::NamedFunction.new('COALESCE', [arel_table[ancestry_column], Arel.sql("''")])),
-            order
-          )
-        else
-          reorder(Arel.sql("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}"), order)
-        end
-      }
-      scope :ordered_by_ancestry_and, Proc.new { |order| ordered_by_ancestry(order) }
-      scope :path_of, lambda { |object| to_node(object).path }
-
       # Update descendants with new ancestry before save
       before_save :update_descendants_with_new_ancestry
 

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -119,13 +119,9 @@ module Ancestry
       end
     end
 
-    def ancestor_conditions
-      self.ancestry_base_class.ancestor_conditions(self)
-    end
-
     def ancestors depth_options = {}
       return self.ancestry_base_class.none unless ancestors?
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.where ancestor_conditions
+      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
     end
 
     def path_ids
@@ -136,12 +132,8 @@ module Ancestry
       ancestor_ids_in_database + [id]
     end
 
-    def path_conditions
-      self.ancestry_base_class.path_conditions(self)
-    end
-
     def path depth_options = {}
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.where path_conditions
+      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
     end
 
     def depth
@@ -202,12 +194,8 @@ module Ancestry
 
     # Children
 
-    def child_conditions
-      self.ancestry_base_class.child_conditions(self)
-    end
-
     def children
-      self.ancestry_base_class.where child_conditions
+      self.ancestry_base_class.children_of(self)
     end
 
     def child_ids
@@ -230,12 +218,8 @@ module Ancestry
 
     # Siblings
 
-    def sibling_conditions
-      self.ancestry_base_class.sibling_conditions(self)
-    end
-
     def siblings
-      self.ancestry_base_class.where sibling_conditions
+      self.ancestry_base_class.siblings_of(self)
     end
 
     # NOTE: includes self
@@ -259,12 +243,8 @@ module Ancestry
 
     # Descendants
 
-    def descendant_conditions
-      self.ancestry_base_class.descendant_conditions(self)
-    end
-
     def descendants depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).where descendant_conditions
+      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
     end
 
     def descendant_ids depth_options = {}
@@ -277,12 +257,8 @@ module Ancestry
 
     # Indirects
 
-    def indirect_conditions
-      self.ancestry_base_class.indirect_conditions(self)
-    end
-
     def indirects depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).where indirect_conditions
+      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
     end
 
     def indirect_ids depth_options = {}
@@ -295,12 +271,8 @@ module Ancestry
 
     # Subtree
 
-    def subtree_conditions
-      self.ancestry_base_class.subtree_conditions(self)
-    end
-
     def subtree depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).where subtree_conditions
+      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
     end
 
     def subtree_ids depth_options = {}
@@ -322,7 +294,7 @@ module Ancestry
   private
     def unscoped_descendants
       unscoped_where do |scope|
-        scope.where descendant_conditions
+        scope.where self.ancestry_base_class.descendant_conditions(self)
       end
     end
 


### PR DESCRIPTION
Currently, the `where()` code and the actual conditions that go into the where clause are kept separate.

It was a logical step at the time, or it was a mistake. But either way, here we are.


At this time, it makes more sense to move that code together. And to move these conditions to the file related to materialized path