### PR TITLE
Stop using was

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -16,7 +16,7 @@ module Ancestry
         unscoped_descendants.each do |descendant|
           # ... replace old ancestry with new ancestry
           descendant.without_ancestry_callbacks do
-            new_ancestor_ids = path_ids + (descendant.ancestor_ids - path_ids_was)
+            new_ancestor_ids = path_ids + (descendant.ancestor_ids - path_ids_in_database)
             descendant.update_attribute(:ancestor_ids, new_ancestor_ids)
           end
         end
@@ -132,8 +132,8 @@ module Ancestry
       ancestor_ids + [id]
     end
 
-    def path_ids_was
-      ancestor_ids_was + [id]
+    def path_ids_in_database
+      ancestor_ids_in_database + [id]
     end
 
     def path_conditions

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -16,9 +16,8 @@ module Ancestry
         unscoped_descendants.each do |descendant|
           # ... replace old ancestry with new ancestry
           descendant.without_ancestry_callbacks do
-            descendant.update_attribute(
-              :ancestor_ids, path_ids + (descendant.ancestor_ids - path_ids_was)
-            )
+            new_ancestor_ids = path_ids + (descendant.ancestor_ids - path_ids_was)
+            descendant.update_attribute(:ancestor_ids, new_ancestor_ids)
           end
         end
       end

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -92,9 +92,8 @@ module Ancestry
         parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
       end
 
-      # deprecated - probably don't want to use anymore
-      def ancestor_ids_was
-        parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}_was"))
+      def ancestor_ids_in_database
+        parse_ancestry_column(send("#{self.ancestry_base_class.ancestry_column}#{IN_DATABASE_SUFFIX}"))
       end
 
       def ancestor_ids_before_last_save


### PR DESCRIPTION
For earlier rails versions, using `_was` is fine.

But the code really needs to be more explicit here.

In this case, when we are updating our hierarchies, we want to change from the previously saved version to the new version.