### PR TITLE
Update ancestor_ids not ancestor_column

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -142,7 +142,7 @@ module Ancestry
             # ... set its ancestry to nil if invalid
             if !node.valid? and !node.errors[node.class.ancestry_column].blank?
               node.without_ancestry_callbacks do
-                node.update_attribute node.ancestry_column, nil
+                node.update_attribute :ancestor_ids, []
               end
             end
             # ... save parent id of this node in parent_ids array if it exists


### PR DESCRIPTION
all but one reference are updating the ancestor_ids column

This is a moot point to be honest, behind the scenes, it is just
updating the ancestors field in the database, but this gives us
some indirection so we can change the ancestor encoding scheme