### PR TITLE
Delimiter definition

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -1,8 +1,5 @@
 module Ancestry
   module InstanceMethods
-    BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save' : '_was'
-    IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database' : '_was'
-
     # Validate that the ancestors don't include itself
     def ancestry_exclude_self
       errors.add(:base, "#{self.class.name.humanize} cannot be a descendant of itself.") if ancestor_ids.include? self.id

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -16,10 +16,6 @@ module Ancestry
       where(arel_table[ancestry_column].eq(nil))
     end
 
-    def path_ids
-      "#{read_attribute(self.ancestry_base_class.ancestry_column)}/#{id}"
-    end
-
     def ancestors_of(object)
       t = arel_table
       node = to_node(object)

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -2,6 +2,7 @@ module Ancestry
   module MaterializedPath
     BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save' : '_was'
     IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database' : '_was'
+    ANCESTRY_DELIMITER='/'.freeze
 
     def self.extended(base)
       base.send(:include, InstanceMethods)
@@ -93,7 +94,6 @@ module Ancestry
     end
 
     module InstanceMethods
-      ANCESTRY_DELIMITER='/'.freeze
 
       # Validates the ancestry, but can also be applied if validation is bypassed to determine if children should be affected
       def sane_ancestry?
@@ -109,7 +109,7 @@ module Ancestry
 
       def ancestor_ids=(value)
         col = self.ancestry_base_class.ancestry_column
-        value.present? ? write_attribute(col, value.join("/")) : write_attribute(col, nil)
+        value.present? ? write_attribute(col, value.join(ANCESTRY_DELIMITER)) : write_attribute(col, nil)
       end
 
       def ancestor_ids

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -1,7 +1,7 @@
 module Ancestry
   module MaterializedPath
-    BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save' : '_was'
-    IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database' : '_was'
+    BEFORE_LAST_SAVE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_before_last_save'.freeze : '_was'.freeze
+    IN_DATABASE_SUFFIX = ActiveRecord::VERSION::STRING >= '5.1.0' ? '_in_database'.freeze : '_was'.freeze
     ANCESTRY_DELIMITER='/'.freeze
 
     def self.extended(base)


### PR DESCRIPTION
freeze constants
use delimiter and define it at a higher level

remove mistake path_ids optimization (sorry - my bad)