### PR TITLE
test fixes

### DIFF
--- a/test/concerns/counter_cache_test.rb
+++ b/test/concerns/counter_cache_test.rb
@@ -77,4 +77,15 @@ class CounterCacheTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_counter_cache_when_updating_record
+    AncestryTestDatabase.with_model :depth => 2, :width => 2, :counter_cache => true, :extra_columns => {:name => :string} do |model, roots|
+      parent = roots.first.first
+      child = parent.children.first
+
+      assert_difference 'parent.reload.children_count', 0 do
+        child.update :name => "name2"
+      end
+    end
+  end
 end

--- a/test/concerns/integrity_checking_and_restoration_test.rb
+++ b/test/concerns/integrity_checking_and_restoration_test.rb
@@ -21,7 +21,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
 
     AncestryTestDatabase.with_model :width => 3, :depth => 3 do |model, roots|
       # Check detection of non-existent ancestor
-      roots.first.first.update_attribute model.ancestry_column, 35
+      roots.first.first.update_attribute :ancestor_ids, [35]
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end
@@ -31,7 +31,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
     AncestryTestDatabase.with_model :width => 3, :depth => 3 do |model, roots|
       # Check detection of cyclic ancestry
       node = roots.first.first
-      node.update_attribute model.ancestry_column, node.id
+      node.update_attribute :ancestor_ids, [node.id]
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end
@@ -41,7 +41,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
     AncestryTestDatabase.with_model do |model|
       # Check detection of conflicting parent id
       model.destroy_all
-      model.create!(model.ancestry_column => model.create!(model.ancestry_column => model.create!(model.ancestry_column => nil).id).id)
+      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => nil).id]).id])
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end
@@ -71,21 +71,21 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
 
     # Check that integrity is restored for non-existent ancestor
     AncestryTestDatabase.with_model :width => width, :depth => depth do |model, roots|
-      roots.first.first.update_attribute model.ancestry_column, 35
+      roots.first.first.update_attribute :ancestor_ids, [35]
       assert_integrity_restoration model
     end
 
     # Check that integrity is restored for cyclic ancestry
     AncestryTestDatabase.with_model :width => width, :depth => depth do |model, roots|
       node = roots.first.first
-      node.update_attribute model.ancestry_column, node.id
+      node.update_attribute :ancestor_ids, [node.id]
       assert_integrity_restoration model
     end
 
     # Check that integrity is restored for conflicting parent id
     AncestryTestDatabase.with_model do |model|
       model.destroy_all
-      model.create!(model.ancestry_column => model.create!(model.ancestry_column => model.create!(model.ancestry_column => nil).id).id)
+      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => nil).id]).id])
       assert_integrity_restoration model
     end
   end


### PR DESCRIPTION
Use ancestor_ids in tests
getting away from directly using ancestry column so we can go towards various column encoding schemes.

Added counter cache test. (was going to update the way the counter cache used the ancestry column name, but didn't want to introduce the change