### PR TITLE
A Way to optimize for Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.6
 
 env:
+  - DB=pg OPTIMIZER=true
   - DB=pg
   - DB=mysql2
   - DB=sqlite3

--- a/README.md
+++ b/README.md
@@ -468,6 +468,11 @@ appraisal rake test
 appraisal sqlite3-ar-50 rake test
 ```
 
+# Optimization
+
+Ancestry provides a way to optimize for specific database. Currently, there is a optimizer for Postgres.
+To enable it, you need to include: `require 'ancestry/optimizers/pg'` after `require 'ancestry'`.
+
 # Internals
 
 Ancestry stores a path from the root to the parent for every node.

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -1,6 +1,7 @@
 require_relative 'ancestry/version'
 require_relative 'ancestry/class_methods'
 require_relative 'ancestry/instance_methods'
+require_relative 'ancestry/optimizer'
 require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -24,6 +24,10 @@ module Ancestry
       # Include instance methods
       include Ancestry::InstanceMethods
 
+      if Ancestry.optimizer
+        include Ancestry.optimizer
+      end
+
       # Include dynamic class methods
       extend Ancestry::ClassMethods
 

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -24,9 +24,7 @@ module Ancestry
       # Include instance methods
       include Ancestry::InstanceMethods
 
-      if Ancestry.optimizer
-        include Ancestry.optimizer
-      end
+      include Ancestry.optimizer if Ancestry.optimizer
 
       # Include dynamic class methods
       extend Ancestry::ClassMethods

--- a/lib/ancestry/optimizer.rb
+++ b/lib/ancestry/optimizer.rb
@@ -1,0 +1,9 @@
+module Ancestry
+  class << self
+    attr_reader :optimizer
+
+    def optimizer= klass
+      @optimizer ||= klass
+    end
+  end
+end

--- a/lib/ancestry/optimizers/pg.rb
+++ b/lib/ancestry/optimizers/pg.rb
@@ -1,0 +1,26 @@
+module Ancestry
+  module Optimizers
+    module Pg
+      # Update descendants with new ancestry (before save)
+      def update_descendants_with_new_ancestry
+        # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
+        if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestry?
+          column = self.ancestry_base_class.ancestry_column.to_s
+          old_ancestry = self.child_ancestry
+          new_ancestry = ancestors? ? "#{read_attribute self.class.ancestry_column }/#{id}" : id.to_s
+          update_clause = [
+            "#{column} = regexp_replace(#{column}, '^#{old_ancestry}', '#{new_ancestry}')"
+          ]
+          if self.ancestry_base_class.respond_to?(:depth_cache_column) && self.respond_to?(self.ancestry_base_class.depth_cache_column)
+            column = self.ancestry_base_class.depth_cache_column.to_s
+            update_clause << "#{column} = length(regexp_replace(regexp_replace(ancestry, '^#{old_ancestry}', '#{new_ancestry}'), '\\d', '', 'g')) + 1"
+          end
+
+          unscoped_descendants.update_all update_clause.join(", ")
+        end
+      end
+    end
+  end
+end
+
+Ancestry.optimizer = Ancestry::Optimizers::Pg

--- a/lib/ancestry/optimizers/pg.rb
+++ b/lib/ancestry/optimizers/pg.rb
@@ -5,18 +5,19 @@ module Ancestry
       def update_descendants_with_new_ancestry
         # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
         if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestry?
-          column = self.ancestry_base_class.ancestry_column.to_s
-          old_ancestry = self.child_ancestry
-          new_ancestry = ancestors? ? "#{read_attribute self.class.ancestry_column }/#{id}" : id.to_s
+          ancestry_column = ancestry_base_class.ancestry_column
+          old_ancestry = child_ancestry
+          new_ancestry = ancestors? ? "#{read_attribute ancestry_column}/#{id}" : id.to_s
           update_clause = [
-            "#{column} = regexp_replace(#{column}, '^#{old_ancestry}', '#{new_ancestry}')"
+            "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{old_ancestry}', '#{new_ancestry}')"
           ]
-          if self.ancestry_base_class.respond_to?(:depth_cache_column) && self.respond_to?(self.ancestry_base_class.depth_cache_column)
-            column = self.ancestry_base_class.depth_cache_column.to_s
-            update_clause << "#{column} = length(regexp_replace(regexp_replace(ancestry, '^#{old_ancestry}', '#{new_ancestry}'), '\\d', '', 'g')) + 1"
+
+          if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
+            depth_cache_column = ancestry_base_class.depth_cache_column.to_s
+            update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{old_ancestry}', '#{new_ancestry}'), '\\d', '', 'g')) + 1"
           end
 
-          unscoped_descendants.update_all update_clause.join(", ")
+          unscoped_descendants.update_all update_clause.join(', ')
         end
       end
     end

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -47,8 +47,9 @@ class AncestryTestDatabase
       File.expand_path('../database.ci.yml', __FILE__)
     end
 
+    use_optimizer
+
     # Setup database connection
-    db_type = ENV["DB"].presence || "sqlite3"
     config = YAML.load_file(filename)[db_type]
     ActiveRecord::Base.establish_connection config
     begin
@@ -117,6 +118,23 @@ class AncestryTestDatabase
         [node, create_test_nodes(model, depth - 1, width, node)]
       end
     else; []; end
+  end
+
+  private
+
+  def self.use_optimizer
+    use_optimizer = ENV['OPTIMIZER'] == 'true'
+    return unless use_optimizer
+
+    if db_type == 'pg'
+      require File.expand_path('../../lib/ancestry/optimizers/pg', __FILE__)
+    else
+      raise "Database Type #{db_type} does not implement optimizer"
+    end
+  end
+
+  def self.db_type
+    ENV["DB"].presence || "sqlite3"
   end
 end
 


### PR DESCRIPTION
# Summary

Currently, there is no way to make optimization for a specific database.
This PR is to give an approach to help a developer use database techniques to do optimization.
For example, the origin of `update_descendants_with_new_ancestry` has a lot of N+1 queries to update all descendants. By using `regexp_replace` on Postgres, we can use one query to remove N+1.

Related Issue: https://github.com/stefankroes/ancestry/issues/282