### PR TITLE
Update readme instructions for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ provide a more detailed explanation:
 
 
 4.  Generate ancestry columns
-    *   In './script.console': **[model].build_ancestry_from_parent_ids!**
+    *   In 'rails console': **[model].build_ancestry_from_parent_ids!**
     *   Make sure it worked ok: **[model].check_ancestry_integrity!**
 
 


### PR DESCRIPTION
Update the outdated `./script` directory which is no longer part of rails, to simply run rails console.