### PR TITLE
cache ancestor_ids

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -104,12 +104,17 @@ module Ancestry
       alias :has_parent? :ancestors?
 
       def ancestor_ids=(value)
+        @_ancestor_ids = nil
+        @_depth        = nil
+
+        # can't assign to `nil` since `nil` could be a valid result
+        remove_instance_variable(:@_parent_id) if defined?(@_parent_id)
         col = self.ancestry_base_class.ancestry_column
         value.present? ? write_attribute(col, value.join(ANCESTRY_DELIMITER)) : write_attribute(col, nil)
       end
 
       def ancestor_ids
-        parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
+        @_ancestor_ids ||= parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
       end
 
       def ancestor_ids_in_database


### PR DESCRIPTION
This is intended as a start to the PR for moving the remainder of the ancestor_ids caching that miq does currently. 

There will need to be a few changes if it needs to be working on the 3.0.7 version. 
The `parent_id` method in particular will need to change on since `cast_primary_key` is recent. 