### PR TITLE
[POC] rails attribute for ancestor_ids

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -71,4 +71,76 @@ module Ancestry
   def self.default_primary_key_format=(value)
     @@default_primary_key_format = value
   end
+
+  # TODO: move out of here
+  # used for materialized path
+  class MaterializedPathString < ActiveRecord::Type::Value
+    def initialize(casting: :to_i, delimiter: '/')
+      @casting = casting&.to_proc
+      @delimiter = delimiter
+    end
+
+    def type
+      :materialized_path_string
+    end
+
+    # convert to database type
+    def serialize(value)
+      if value.kind_of?(Array)
+        value.map(&:to_s).join(@delimiter).presence
+      elsif value.kind_of?(Integer)
+        value.to_s
+      elsif value.nil? || value.kind_of?(String)
+        value
+      else
+        byebug
+        puts "curious type: #{value.class}"
+      end
+    end
+
+    def cast(value)
+      cast_value(value) #unless value.nil? (want to get rid of this - fix default value)
+    end
+
+    # called by cast (form or setter) or deserialize (database)
+    def cast_value(value)
+      if value.kind_of?(Array)
+        super
+      elsif value.nil?
+        # would prefer to use default here
+        # but with default, it kept thinking the field had changed when it hadn't
+        super([])
+      else
+        #TODO: test ancestry=1
+        super(value.to_s.split(@delimiter).map(&@casting))
+      end
+    end
+  end
+end
+ActiveRecord::Type.register(:materialized_path_string, Ancestry::MaterializedPathString)
+
+class ArrayPatternValidator < ActiveModel::EachValidator
+  def initialize(options)
+    raise ArgumentError, "Pattern unspecified, Specify using :pattern" unless options[:pattern]
+
+    options[:pattern] = /\A#{options[:pattern].to_s}\Z/ unless options[:pattern].to_s.include?('\A')
+    options[:id] = true unless options.key?(:id)
+    options[:integer] = true unless options.key?(:integer)
+
+    super
+  end
+
+  def validate_each(record, attribute, value)
+    if options[:id] && value.include?(record.id)
+      record.errors.add(attribute, I18n.t("ancestry.exclude_self", {:class_name => self.class.name.humanize}))
+    end
+
+    if value.any? { |v| v.to_s !~ options[:pattern] }
+      record.errors.add(attribute, "illegal characters")
+    end
+
+    if options[:integer] && value.any? { |v| v < 1 }
+      record.errors.add(attribute, "non positive ancestor id")
+    end
+  end
 end

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -93,6 +93,9 @@ module Ancestry
 
     # Pseudo-preordered array of nodes.  Children will always follow parents,
     # This is deterministic unless the parents are missing *and* a sort block is specified
+    # for ordering nodes within a rank provide block, eg. Node.sort_by_ancestry(Node.all) {|a, b| a.rank <=> b.rank}.
+    EMPTY_ANCESTRY=[0].freeze
+    # TODO: use ancestor_ids over ancestry
     def sort_by_ancestry(nodes, &block)
       arranged = nodes if nodes.is_a?(Hash)
 
@@ -256,15 +259,6 @@ module Ancestry
 
     def unscoped_where
       yield ancestry_base_class.default_scoped.unscope(:where)
-    end
-
-    ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze
-    def primary_key_is_an_integer?
-      if defined?(@primary_key_is_an_integer)
-        @primary_key_is_an_integer
-      else
-        @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key).type)
-      end
     end
   end
 end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -40,6 +40,7 @@ module Ancestry
       # Include dynamic class methods
       extend Ancestry::ClassMethods
 
+      # array?
       if ancestry_format == :materialized_path2
         extend Ancestry::MaterializedPath2
       else
@@ -50,11 +51,14 @@ module Ancestry
 
       validates self.ancestry_column, ancestry_validation_options(primary_key_format)
 
+      pi = "a" !~ primary_key_format # want to know primary_key_is_an_integer? without accessing the database
+
+      attribute ancestry_column, :materialized_path_string, :casting => pi ? :to_i : :to_s, :delimiter => ancestry_delimiter
+      validates ancestry_column, :array_pattern => {:id => true, :pattern => primary_key_format, :integer => pi}
+      alias_attribute :ancestor_ids, ancestry_column
+
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
       include Ancestry::MaterializedPathPg if update_strategy == :sql
-
-      # Validate that the ancestor ids don't include own id
-      validate :ancestry_exclude_self
 
       # Update descendants with new ancestry after update
       after_update :update_descendants_with_new_ancestry, if: :ancestry_changed?

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -1,10 +1,5 @@
 module Ancestry
   module InstanceMethods
-    # Validate that the ancestors don't include itself
-    def ancestry_exclude_self
-      errors.add(:base, I18n.t("ancestry.exclude_self", class_name: self.class.name.humanize)) if ancestor_ids.include? self.id
-    end
-
     # Update descendants with new ancestry (after update)
     def update_descendants_with_new_ancestry
       # If enabled and the new ancestry is sane ...
@@ -98,6 +93,10 @@ module Ancestry
       end
 
       parent_id && increase_parent_counter_cache
+    end
+
+    def parent_id_before_last_save
+      ancestor_ids_before_last_save.last
     end
 
     # Ancestors

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -37,7 +37,7 @@ module Ancestry
     def indirects_of(object)
       t = arel_table
       node = to_node(object)
-      where(t[ancestry_column].matches("#{node.child_ancestry}#{ancestry_delimiter}%", nil, true))
+      where(t[ancestry_column].matches("#{node.child_ancestry.join(ancestry_delimiter)}%", nil, true))
     end
 
     def descendants_of(object)
@@ -46,7 +46,8 @@ module Ancestry
 
     def descendants_by_ancestry(ancestry)
       t = arel_table
-      t[ancestry_column].matches("#{ancestry}#{ancestry_delimiter}%", nil, true).or(t[ancestry_column].eq(ancestry))
+      # TODO: broken. loosing pre delimiter (want to concat ancestry with %)
+      t[ancestry_column].matches("#{node.child_ancestry.join("/")}/%", nil, true).or(t[ancestry_column].eq(node.child_ancestry.join("/")))
     end
 
     def descendant_conditions(object)
@@ -89,7 +90,7 @@ module Ancestry
     end
 
     def ancestry_root
-      nil
+      []
     end
 
     def child_ancestry_sql
@@ -163,17 +164,17 @@ module Ancestry
         write_attribute(self.class.ancestry_column, self.class.generate_ancestry(value))
       end
 
-      def ancestor_ids
-        self.class.parse_ancestry_column(read_attribute(self.class.ancestry_column))
-      end
+      # def ancestor_ids
+      #   self.class.parse_ancestry_column(read_attribute(self.class.ancestry_column))
+      # end
 
-      def ancestor_ids_in_database
-        self.class.parse_ancestry_column(attribute_in_database(self.class.ancestry_column))
-      end
+      # def ancestor_ids_in_database
+      #   self.class.parse_ancestry_column(attribute_in_database(self.class.ancestry_column))
+      # end
 
-      def ancestor_ids_before_last_save
-        self.class.parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
-      end
+      # def ancestor_ids_before_last_save
+      #   self.class.parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
+      # end
 
       def parent_id_in_database
         self.class.parse_ancestry_column(attribute_in_database(self.class.ancestry_column)).last

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -94,16 +94,4 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
       end
     end
   end
-
-  def test_primary_key_is_an_integer
-    AncestryTestDatabase.with_model(extra_columns: { string_id: :string }) do |model|
-      model.primary_key = :string_id
-
-      assert !model.primary_key_is_an_integer?
-    end
-
-    AncestryTestDatabase.with_model do |model|
-      assert model.primary_key_is_an_integer?
-    end
-  end
 end

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -72,11 +72,6 @@ class OphanStrategiesTest < ActiveSupport::TestCase
       assert_equal n3.parent_id, n1.id, "orphan's not parentified"
       assert_equal n5.ancestor_ids, [n1.id, n4.id], "ancestry integrity not maintained"
       n1.destroy                          # delete a root node with desecendants
-      n3.reload
-      n5.reload
-      assert_nil n3.parent_id, " new root node should have no parent"
-      assert n3.valid?, " new root node is not valid"
-      assert_equal n5.ancestor_ids, [n4.id], "ancestry integrity not maintained"
     end
   end
 
@@ -150,6 +145,11 @@ class OphanStrategiesTest < ActiveSupport::TestCase
       model.create! # a node that is not affected
       assert_difference 'model.count', -4 do
         root.destroy
+      # TODO: are these the same?
+      if AncestryTestDatabase.materialized_path2?
+        assert_equal(model.find(n3.id).ancestry, model.ancestry_root, " new root node has no root ancestry string")
+      else
+        assert_nil(model.find(n3.id).ancestry," new root node has no empty ancestry string")
       end
     end
   end


### PR DESCRIPTION
Rails has a concept of serializing attributes. They even allow you to define a custom serializer.

So the concept of `ancestry` and `ancestor_ids` are merged, and the delimiter basically goes away.

So from there, I merged them over to the `ancestor_ids` concept and saw if it was possible to rename fields based upon ancestor_ids. If this is possible, it may be possible to have multiple ancestors.

Dropping 4.2 to simplify this support.