### PR TITLE
Better humanise model name for error message

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module InstanceMethods
     # Validate that the ancestors don't include itself
     def ancestry_exclude_self
-      errors.add(:base, "#{self.class.name.humanize} cannot be a descendant of itself.") if ancestor_ids.include? self.id
+      errors.add(:base, "#{self.class.model_name.human} cannot be a descendant of itself.") if ancestor_ids.include? self.id
     end
 
     # Update descendants with new ancestry (before save)


### PR DESCRIPTION
Imagine a model called `ProductType`. The old message was:

> Producttype cannot be a descendant of itself.

The new message is:

> Product type cannot be a descendant of itself.

There is probably an even better way of making the whole message translatable but I didn't look into that.