### PR TITLE
simplify mysql ordering

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -75,13 +75,15 @@ module Ancestry
     end
 
     def ordered_by_ancestry(order = nil)
-      if %w(mysql mysql2 sqlite sqlite3 postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::MAJOR >= 5
+      if %w(mysql mysql2 sqlite sqlite3).include?(connection.adapter_name.downcase)
+        reorder(arel_table[ancestry_column], order)
+      elsif %w(postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::STRING >= "6.1"
+        reorder(Arel::Nodes.new(arel_table[ancestry_column]).nulls_first)
+      else
         reorder(
           Arel::Nodes::Ascending.new(Arel::Nodes::NamedFunction.new('COALESCE', [arel_table[ancestry_column], Arel.sql("''")])),
           order
         )
-      else
-        reorder(Arel.sql("(CASE WHEN #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} IS NULL THEN 0 ELSE 1 END), #{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)}"), order)
       end
     end
 


### PR DESCRIPTION
was asked to open by KB, it's stolen directly from https://github.com/stefankroes/ancestry/issues/486
thanks @brendon 


per that issue, MySQL's default is NULL FIRST; we don't care about activesupport 4.2 any more so the version check can be removed, and the else clause is also no longer necessary (see https://github.com/stefankroes/ancestry/pull/490#discussion_r456938446)