### PR TITLE
Update changelog date for 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Doing our best at supporting [SemVer](http://semver.org/) with
 a nice looking [Changelog](http://keepachangelog.com).
 
-## Versions [3.1.0] <small>2018-11-06</small>
+## Versions [3.1.0] <small>2020-08-03</small>
 
 * `:primary_key_format` method lets you change syntax. good for uuids.
 * changed code from being `ancestry` string to `ancestry_ids` focused. May break monkey patches.


### PR DESCRIPTION
## Why

I was a bit surprised to see an update "popping up" from dependabot with the last changed said to be in 2018... so I started looking at what triggered this update to trigger before realizing it was just probably a simple copy-typo.

## What

Update the date in the chagelog; I used the "UTC" date of the release for this. 