### PR TITLE
Update tests versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ gemfile:
   - gemfiles/gemfile_52.gemfile
   - gemfiles/gemfile_60.gemfile
 
+jobs:
+  exclude:
+    - rvm: 2.7
+      gemfile: gemfiles/gemfile_42.gemfile
+
 services:
   - mysql
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: bundler
 rvm:
   - 2.5
   - 2.6
+  - 2.7
 
 env:
   - DB=pg

--- a/gemfiles/gemfile_42.gemfile
+++ b/gemfiles/gemfile_42.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "4.2.10"
+gem "activerecord", "4.2.11.3"
 gem "coveralls", require: false
 gem "mysql2", "~> 0.4.0"
 gem "pg", "0.18.4"

--- a/gemfiles/gemfile_50.gemfile
+++ b/gemfiles/gemfile_50.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.0.7"
+gem "activerecord", "5.0.7.2"
 gem "coveralls", require: false
 gem "mysql2"
 gem "pg"

--- a/gemfiles/gemfile_52.gemfile
+++ b/gemfiles/gemfile_52.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.3"
+gem "activerecord", "5.2.4.3"
 gem "coveralls", require: false
 gem "mysql2"
 gem "pg"

--- a/gemfiles/gemfile_60.gemfile
+++ b/gemfiles/gemfile_60.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.0.0"
+gem "activerecord", "6.0.3.2"
 gem "coveralls", require: false
 gem "mysql2"
 gem "pg"


### PR DESCRIPTION
## Why

Be sure there is no problem with the currently maintained ruby version.
Also ensures there is no problem with the currently maintained - or latest for each supported minor version - of rails.

## What

- Add testing with ruby 2.7 (exclude rails <5 [when doing so](https://stackoverflow.com/questions/9087116/which-ruby-on-rails-is-compatible-with-which-ruby-version))
- Use the latest of each respective minor rails/activerecord versions.