### PR TITLE
remove code for old activerecord versions

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -207,31 +207,15 @@ module Ancestry
     end
 
     def unscoped_where
-      if ActiveRecord::VERSION::MAJOR < 4
-        self.ancestry_base_class.unscoped do
-          yield self.ancestry_base_class
-        end
-      else
-        yield self.ancestry_base_class.unscope(:where)
-      end
+      yield self.ancestry_base_class.unscope(:where)
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze
-    if ActiveSupport::VERSION::STRING < "4.2"
-      def primary_key_is_an_integer?
-        if defined?(@primary_key_is_an_integer)
-          @primary_key_is_an_integer
-        else
-          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(columns_hash[primary_key.to_s].type)
-        end
-      end
-    else
-      def primary_key_is_an_integer?
-        if defined?(@primary_key_is_an_integer)
-          @primary_key_is_an_integer
-        else
-          @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key).type)
-        end
+    def primary_key_is_an_integer?
+      if defined?(@primary_key_is_an_integer)
+        @primary_key_is_an_integer
+      else
+        @primary_key_is_an_integer = !ANCESTRY_UNCAST_TYPES.include?(type_for_attribute(primary_key).type)
       end
     end
   end

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -116,4 +116,4 @@ puts "  Ruby: #{RUBY_VERSION}"
 puts "  ActiveRecord: #{ActiveRecord::VERSION::STRING}"
 puts "  Database: #{ActiveRecord::Base.connection.adapter_name}\n\n"
 
-require 'minitest/autorun' if ActiveSupport::VERSION::STRING > "4"
+require 'minitest/autorun'

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -16,20 +16,6 @@ ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 require 'active_record'
 require 'logger'
 
-# Rails 3.2 has issues with mysql 5.7, primary key not being null.
-# See https://stackoverflow.com/questions/33742967
-if ActiveRecord::VERSION::MAJOR < 4
-  begin
-    require 'active_record/connection_adapters/mysql_adapter'
-    ActiveRecord::ConnectionAdapters::MysqlAdapter
-    class ActiveRecord::ConnectionAdapters::MysqlAdapter
-      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
-    end
-  rescue LoadError
-    # not running with mysql, don't monkey patch
-  end
-end
-
 # Make absolutely sure we are testing local ancestry
 require File.expand_path('../../lib/ancestry', __FILE__)
 


### PR DESCRIPTION
do we still need any of this? 

i think we're locked to >= 4.2

the monkey patch and unscoped_where if clause are < 4, the primary key as int thing is < 4.2 

really my goal is to get the test coverage to 100 and clearly the way to do that is taking code out
/s