### PR TITLE
Remove postgresql check for :sql update strategy

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -31,7 +31,7 @@ module Ancestry
       extend Ancestry::MaterializedPath
 
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
-      include Ancestry::MaterializedPathPg if update_strategy == :sql && ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+      include Ancestry::MaterializedPathPg if update_strategy == :sql
 
       # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
       cattr_reader :orphan_strategy

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -55,7 +55,7 @@ class AncestryTestDatabase
 
       # This only affects postgres
       # the :ruby code path will get tested in mysql and sqlite3
-      Ancestry.default_update_strategy = :sql if ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+      Ancestry.default_update_strategy = :sql if db_type == "pg"
 
     rescue => err
       if ENV["CI"]

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -47,15 +47,16 @@ class AncestryTestDatabase
       File.expand_path('../database.ci.yml', __FILE__)
     end
 
-    # This only affects postgres
-    # the :ruby code path will get tested in mysql and sqlite3
-    Ancestry.default_update_strategy = :sql
-
     # Setup database connection
     config = YAML.load_file(filename)[db_type]
     ActiveRecord::Base.establish_connection config
     begin
       ActiveRecord::Base.connection
+
+      # This only affects postgres
+      # the :ruby code path will get tested in mysql and sqlite3
+      Ancestry.default_update_strategy = :sql if ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+
     rescue => err
       if ENV["CI"]
         raise


### PR DESCRIPTION
I was running into an issue when running `rake asset:precompile` in a CI environment since it didn't have any postgres database running. It was failing because `ActiveRecord::Base.connection` tries to connect to the database.

`update_strategy: :sql` is an opt-in option so it's probably not necessary to do the postgres check.

What are your thoughts?