### PR TITLE
Remove require for materialized_path_pg

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,7 +4,6 @@ require_relative 'ancestry/instance_methods'
 require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
-require_relative 'ancestry/materialized_path_pg'
 
 I18n.load_path += Dir[File.join(File.expand_path(File.dirname(__FILE__)),
                                  'ancestry', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
The require for `materialized_path_pg` is breaking v3.2.0. This is a proposed fix for #510.