### PR TITLE
Bundled gem is missing files

### DIFF
--- a/ancestry.gemspec
+++ b/ancestry.gemspec
@@ -14,6 +14,9 @@ Gem::Specification.new do |s|
   of (sub)tree into hashes and different strategies for dealing with orphaned
   records.
 EOF
+
+  s.post_install_message = "Thank you for installing Ancestry. You can visit http://github.com/stefankroes/ancestry to read the documentation."
+
   s.metadata = {
     "homepage_uri" => "https://github.com/stefankroes/ancestry",
     "changelog_uri" => "https://github.com/stefankroes/ancestry/blob/master/CHANGELOG.md",
@@ -27,20 +30,13 @@ EOF
   s.homepage = 'https://github.com/stefankroes/ancestry'
   s.license  = 'MIT'
 
-  s.files = [
-    'ancestry.gemspec',
-    'init.rb',
-    'install.rb',
-    'lib/ancestry.rb',
-    'lib/ancestry/has_ancestry.rb',
-    'lib/ancestry/exceptions.rb',
-    'lib/ancestry/class_methods.rb',
-    'lib/ancestry/instance_methods.rb',
-    'lib/ancestry/materialized_path.rb',
-    'lib/ancestry/version.rb',
+  s.files = Dir[ 
+    "{lib}/**/*"
+    'CHANGELOG.md',
     'MIT-LICENSE',
     'README.md'
   ]
+  s.require_paths = ["lib"]
   
   s.required_ruby_version     = '>= 2.0.0'
   s.add_runtime_dependency 'activerecord', '>= 4.2.0'

--- a/ancestry.gemspec
+++ b/ancestry.gemspec
@@ -31,7 +31,7 @@ EOF
   s.license  = 'MIT'
 
   s.files = Dir[ 
-    "{lib}/**/*"
+    "{lib}/**/*",
     'CHANGELOG.md',
     'MIT-LICENSE',
     'README.md'

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-require 'ancestry'

--- a/install.rb
+++ b/install.rb
@@ -1,1 +1,0 @@
-puts "Thank you for installing Ancestry. You can visit http://github.com/stefankroes/ancestry to read the documentation."


### PR DESCRIPTION
Fix for #510 

The gem found on rubygems.org is missing **materialized_path_pg.rb** as well as the **locales** folder because they are not included in the the gemspec files list. 

```
  s.files = [
    'ancestry.gemspec',
    'init.rb',
    'install.rb',
    'lib/ancestry.rb',
    'lib/ancestry/has_ancestry.rb',
    'lib/ancestry/exceptions.rb',
    'lib/ancestry/class_methods.rb',
    'lib/ancestry/instance_methods.rb',
    'lib/ancestry/materialized_path.rb',
    'lib/ancestry/version.rb',
    'MIT-LICENSE',
    'README.md'
  ]
```

To prevent this from happening in future releases I've standardized the .gemspec, requiring the lib folder by default. I've removed the init.rb and install.rb files which are not needed, and added the CHANGELOG as well.
