### PR TITLE
No need to send a public method "Object#extend"

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -115,5 +115,5 @@ module Ancestry
 end
 
 ActiveSupport.on_load :active_record do
-  send :extend, Ancestry::HasAncestry
+  extend Ancestry::HasAncestry
 end


### PR DESCRIPTION
`Object#extend` has been defined as a public method since the last century (I don't exactly know when, but it already was a public method even on version 1.0.0).
So we don't need to call it via `send`.