### PR TITLE
Fixes Rails 6 Scoping Deprecation Warnings

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -217,7 +217,7 @@ module Ancestry
     end
 
     def unscoped_where
-      yield self.ancestry_base_class.unscope(:where)
+      yield self.ancestry_base_class.default_scoped.unscope(:where)
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze


### PR DESCRIPTION
We recently updated our app to rails 6.0 and noticed one of the deprecation warnings documented in #442.  Specifically:
```
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `<model name>.default_scoped`.
```

After this small change the gem's test passed for me locally, and we have a fairly thorough suite of specs around the ancestry functionality that also passed.  So, I figured it was worth opening a PR for any additional feedback.

Thanks for all your work supporting this gem!