### PR TITLE
Fix order_by_ancestry_and for ActiveRecord 6.1

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -68,7 +68,7 @@ module Ancestry
       if %w(mysql mysql2 sqlite sqlite3).include?(connection.adapter_name.downcase)
         reorder(arel_table[ancestry_column], order)
       elsif %w(postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::STRING >= "6.1"
-        reorder(Arel::Nodes::Ascending.new(arel_table[ancestry_column]).nulls_first)
+        reorder(Arel::Nodes::Ascending.new(arel_table[ancestry_column]).nulls_first, order)
       else
         reorder(
           Arel::Nodes::Ascending.new(Arel::Nodes::NamedFunction.new('COALESCE', [arel_table[ancestry_column], Arel.sql("''")])),


### PR DESCRIPTION
Restored the second arg to `reorder`