### PR TITLE
Fix ordered_by_ancestry for oracle-db

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -69,6 +69,8 @@ module Ancestry
         reorder(arel_table[ancestry_column], order)
       elsif %w(postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::STRING >= "6.1"
         reorder(Arel::Nodes::Ascending.new(arel_table[ancestry_column]).nulls_first, order)
+      elsif %w(oracleenhanced).include?(connection.adapter_name.downcase)
+        reorder(Arel.sql("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(ancestry_column)} ASC NULLS FIRST"), order)
       else
         reorder(
           Arel::Nodes::Ascending.new(Arel::Nodes::NamedFunction.new('COALESCE', [arel_table[ancestry_column], Arel.sql("''")])),


### PR DESCRIPTION
An empty string is treated as NULL in Oracle. 
`COALESCE(NULL,'')` is treated as NULL. 
So Ordering ascending, deliver NULL-Values at the rear.