### PR TITLE
Missing parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.6
+# rails 5.2    ...2.6 (prefer 2.5)
+# rails 6.0 2.5...3.0 (prefer 2.6)
+# rails 6.1 2.5..3.0  (prefer 3.0)
+# rails 6.2 2.5..3.0  (prefer 3.0)
+  - 2.5
   - 3.0
 
 env:
@@ -18,13 +22,13 @@ gemfile:
 jobs:
   include:
     - env: DB=pg
-      rvm: 2.6
+      rvm: 2.5
       gemfile: gemfiles/gemfile_52.gemfile
     - env: DB=mysql2
-      rvm: 2.6
+      rvm: 2.5
       gemfile: gemfiles/gemfile_52.gemfile
     - env: DB=sqlite3
-      rvm: 2.6
+      rvm: 2.5
       gemfile: gemfiles/gemfile_52.gemfile
 
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "activerecord", '~> 5.2.4.5'
+gem "activerecord", "~> 6.0.3"
 gem "coveralls", require: false
 gem "mysql2"
 gem "pg"

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -158,7 +158,11 @@ module Ancestry
     alias :parent_id? :ancestors?
 
     def parent
-      unscoped_find(parent_id) if has_parent?
+      if has_parent?
+        unscoped_where do |scope|
+          scope.find_by id: parent_id
+        end
+      end
     end
 
     def parent_of?(node)

--- a/test/concerns/relations_test.rb
+++ b/test/concerns/relations_test.rb
@@ -1,0 +1,37 @@
+require_relative '../environment'
+
+class RelationsTest < ActiveSupport::TestCase
+  def test_root_found
+    AncestryTestDatabase.with_model do |model|
+      parent = model.create
+      child = model.create!(:ancestor_ids => [parent.id])
+      assert_equal(parent, child.root)
+    end
+  end
+
+  def test_parent_not_found
+    AncestryTestDatabase.with_model do |model|
+      record = model.create
+      # setting the parent_id to something not valid
+      record.update_attribute(:ancestor_ids, [record.id + 1])
+      assert_nil record.root
+    end
+  end
+
+  def test_parent_found
+    AncestryTestDatabase.with_model do |model|
+      parent = model.create
+      child = model.create!(:ancestor_ids => [parent.id])
+      assert_equal(parent, child.parent)
+    end
+  end
+
+  def test_parent_not_found
+    AncestryTestDatabase.with_model do |model|
+      record = model.create
+      # setting the parent_id to something not valid
+      record.update_attribute(:ancestor_ids, [record.id + 1])
+      assert_nil record.parent
+    end
+  end
+end


### PR DESCRIPTION
resolves #523

if an invalid value is in the `parent_id`, `parent` will return nil not throw error