### PR TITLE
oracle use NULLS first

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -67,7 +67,7 @@ module Ancestry
     def ordered_by_ancestry(order = nil)
       if %w(mysql mysql2 sqlite sqlite3).include?(connection.adapter_name.downcase)
         reorder(arel_table[ancestry_column], order)
-      elsif %w(postgresql).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::STRING >= "6.1"
+      elsif %w(postgresql oracleenhanced).include?(connection.adapter_name.downcase) && ActiveRecord::VERSION::STRING >= "6.1"
         reorder(Arel::Nodes::Ascending.new(arel_table[ancestry_column]).nulls_first, order)
       else
         reorder(


### PR DESCRIPTION
the order of nulls relative to columns with values is setup as
a default value in databases, which can be changed. The default for
postgres is to have nulls last. Looks like oracle has the same.

This PR has oracle enhanced driver follow suite as postgres.

Postgres and rails 6.0 and earlier had issues with the null first, so this is
feature limited to 6.1 and later

Alternative to https://github.com/stefankroes/ancestry/pull/535

@d-m-u this is another example of where the defaults of the database can really affect the way this gem works.
Add this to the list of configuration options that we would like to have. So someone can say that nulls first is part of the database and they don't need to add this funky syntax