### PR TITLE
introduce COLLATE_SYMBOLS=false to talor test environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ $ rails g migration add_ancestry_to_[table] ancestry:string:index
 $ rake db:migrate
 ```
 
+Depending upon your comfort with databases, you may want to create the column
+with `C` or `POSIX` encoding. This is a more primitive encoding and just compares
+bytes. Since this column will just contains numbers and slashes, it works much
+better. It also works better for the uuid case as well.
+
+
+If you opt out of this, and are trying to run tests on postgres, you may need to
+set the environment variable `COLLATE_SYMBOLS=false`. Sorry to say that a discussion
+on this topic is out of scope. The important take away is postgres sort order is
+not consistent across operating systems but other databases do not have this same
+issue.
 
 ## Add ancestry to your model
 * Add to app/models/[model.rb]:

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -51,8 +51,9 @@ class ScopesTest < ActiveSupport::TestCase
 
   def test_order_by
     AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, _roots|
-      # not thrilled with this. mac postgres has odd sorting requirements
-      if ENV["DB"].to_s =~ /pg/ && RUBY_PLATFORM !~ /x86_64-darwin/
+      # Some pg databases do not use symbols in sorting
+      # if this is failing, try running the test via DB=pg COLLATE_SYMBOLS=false rake test
+      if ENV["COLLATE_SYMBOLS"].to_s =~ /false/i
         expected = model.all.sort_by { |m| [m.ancestor_ids.map(&:to_s).join, m.id.to_i] }
       else
         expected = model.all.sort_by { |m| [m.ancestor_ids.map(&:to_s), m.id.to_i] }


### PR DESCRIPTION
Most database ship with locales built in so they are consistent across installations.
Postgres does not ship with locales so it uses the ones in the operating system.

In the locales there is collation, which basically defines how to sort. We will mostly
notice this in the following 2 ways:

- case sensitive sorting
- include symbols in the sorting

case sensitive: "B", "E", "c", "d" 
non-case Insensitive: "B", "c", "d", "E"
include symbols: "Sams Golf Shop", "Sam's Cantina"
ignore symbols: "Sam's Cantina", "Sams Golf Shop"

In our domain, the ignoring symbols causes some issues:

include symbols: "1/2/3", "1/2/5", "1/4", "12/4"
ignore symbols: "1/2/3", "12/4", "1/2/5", "1/4" (think alphabetic sort: "123", "125", "14", 124")

If you are ordering them to put into a tree, then this gets confusing and
can result in children coming back out of order. This is tricky for arrange.

An option was introduced for the case when symbols are not considered. It essentially
'join' the strings together to simulate ignoring the symbols.

Also do remember, that this is sorting alphabetically rather than numerically. So 14 > 123.