### PR TITLE
return self if root is invalid

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -176,7 +176,11 @@ module Ancestry
     end
 
     def root
-      has_parent? ? unscoped_find(root_id) : self
+      if has_parent?
+        unscoped_where { |scope| scope.find_by(id: root_id) } || self
+      else
+        self
+      end
     end
 
     def is_root?

--- a/test/concerns/relations_test.rb
+++ b/test/concerns/relations_test.rb
@@ -9,12 +9,12 @@ class RelationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_parent_not_found
+  def test_root_not_found
     AncestryTestDatabase.with_model do |model|
       record = model.create
       # setting the parent_id to something not valid
       record.update_attribute(:ancestor_ids, [record.id + 1])
-      assert_nil record.root
+      assert_equal record.root, record
     end
   end
 


### PR DESCRIPTION
much like we do with parent, if the root_id is invalid, then we continue on
as if nothing has happened wrong.

It was hard to decide what to return but returning root seems like the best option.

continuation of #523 