### PR TITLE
Add tree_view method

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -74,6 +74,22 @@ module Ancestry
       end
     end
 
+     # Fix for issue #559: implements tree_view from the arrange method
+     # returns tree_view of a subtree
+    def tree_view(column, data = nil)
+      data = arrange unless data
+      data.each do |parent, children|
+        if parent.depth == 0
+          puts parent[column]
+        else
+          num = parent.depth - 1
+          indent = "   "*num
+          puts " #{"|" if parent.depth > 1}#{indent}|_ #{parent[column]}"
+        end
+        tree_view(column, children) if children
+      end
+    end
+
     # Pseudo-preordered array of nodes.  Children will always follow parents,
     def sort_by_ancestry(nodes, &block)
       arranged = nodes if nodes.is_a?(Hash)

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -74,8 +74,6 @@ module Ancestry
       end
     end
 
-     # Fix for issue #559: implements tree_view from the arrange method
-     # returns tree_view of a subtree
     def tree_view(column, data = nil)
       data = arrange unless data
       data.each do |parent, children|


### PR DESCRIPTION
This adds the funcionality for: #559.
For Example:

arrange method:
```
message.subtree.arrange
```
```
{#<Message:0x000055f62357a930 id: 9, content: "This is a root message", created_at: Tue, 23 Nov 2021 05:04:04.053540000 UTC +00:00, updated_at: Tue, 23 Nov 2021 05:04:04.053540000 UTC +00:00, ancestry: nil>=>
  {#<Message:0x000055f62357a048 id: 10, content: "this is a reply", created_at: Tue, 23 Nov 2021 05:04:50.832312000 UTC +00:00, updated_at: Tue, 23 Nov 2021 05:04:50.832312000 UTC +00:00, ancestry: "9">=>
    {#<Message:0x000055f623578b58 id: 12, content: "this is a reply to a rply", created_at: Tue, 23 Nov 2021 05:05:48.845504000 UTC +00:00, updated_at: Tue, 23 Nov 2021 05:05:48.845504000 UTC +00:00, ancestry: "9/10">=>{}},
   #<Message:0x000055f6235796c0 id: 11, content: "this is another reply", created_at: Tue, 23 Nov 2021 05:05:00.767846000 UTC +00:00, updated_at: Tue, 23 Nov 2021 05:05:00.767846000 UTC +00:00, ancestry: "9">=>
    {}
  }
}
```
tree_view method:
```
message.subtree.tree_view(:content)
```
```
This is a root message
 |_ this is a reply
 |   |_ this is a reply to a rply
 |_ this is another reply
```