### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ bundle install
 
 ```bash
 $ rails g migration add_ancestry_to_[table] ancestry:string:index
+# or use different column name of your choosing. e.g. name:
+# rails g migration add_name_to_[people] name:string:index
 ```
 
 *   Migrate your database:
@@ -74,7 +76,8 @@ NOTE: A Btree index (as is recommended) has a limitaton of 2704 characters for t
 # app/models/[model.rb]
 
 class [Model] < ActiveRecord::Base
-   has_ancestry
+   has_ancestry # or alternatively as below:
+   # has_ancestry ancestry_column: :name ## if you've used a different column name
 end
 ```
 


### PR DESCRIPTION
### What is this PR?

* Add detail re: customizing column names.

### Why is it required?

Because it may not be convenient to name the column: 'ancestry' - I imagine (perhaps incorrectly) that many would prefer to customize the column name to something better suited to their use-cases (e.g. https://github.com/stefankroes/ancestry/issues/273).

I hope this change is helpful - if it is not, feel free to close without compunction etc.