### PR TITLE
Use `ensure` to revert @disable_ancestry_callbacks

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -297,6 +297,7 @@ module Ancestry
     def without_ancestry_callbacks
       @disable_ancestry_callbacks = true
       yield
+    ensure
       @disable_ancestry_callbacks = false
     end
 


### PR DESCRIPTION
Hello, I ran into a problem because I need the return of the block passed to `without_ancestry_callbacks`:

```rb
# always returns false instead of the result of inner_block
def some_method
  without_ancestry_callbacks { inner_block } 
end
```

So I think that `ensure` is a good fit here.

Note, this is probably a breaking change (although I think no one is relying on the result of `without_ancestry_callbacks` right now), so should we create a new method for this?