### PR TITLE
remove EOL service hakiri from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://badges.gitter.im/Join+Chat.svg)](https://gitter.im/stefankroes/ancestry?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Security](https://hakiri.io/github/stefankroes/ancestry/master.svg)](https://hakiri.io/github/stefankroes/ancestry/master)
+[![Gitter](https://badges.gitter.im/Join+Chat.svg)](https://gitter.im/stefankroes/ancestry?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Ancestry
 


### PR DESCRIPTION
Service went away.

Github has dependabot which seems to provide similar functionality.

darn, forgot to add `[skip ci]` to the commit message.