### PR TITLE
update_descendants_with_new_ancestry in after_update

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -45,8 +45,8 @@ module Ancestry
       # Validate that the ancestor ids don't include own id
       validate :ancestry_exclude_self
 
-      # Update descendants with new ancestry before save
-      before_save :update_descendants_with_new_ancestry
+      # Update descendants with new ancestry after update
+      after_update :update_descendants_with_new_ancestry
 
       # Apply orphan strategy before destroy
       before_destroy :apply_orphan_strategy

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -1,11 +1,11 @@
 module Ancestry
   module MaterializedPathPg
-    # Update descendants with new ancestry (before save)
+    # Update descendants with new ancestry (after update)
     def update_descendants_with_new_ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
         ancestry_column = ancestry_base_class.ancestry_column
-        old_ancestry = path_ids_in_database.join(Ancestry::MaterializedPath::ANCESTRY_DELIMITER)
+        old_ancestry = path_ids_before_last_save.join(Ancestry::MaterializedPath::ANCESTRY_DELIMITER)
         new_ancestry = path_ids.join(Ancestry::MaterializedPath::ANCESTRY_DELIMITER)
         update_clause = [
           "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{old_ancestry}', '#{new_ancestry}')"
@@ -16,7 +16,7 @@ module Ancestry
           update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{old_ancestry}', '#{new_ancestry}'), '\\d', '', 'g')) + 1"
         end
 
-        unscoped_descendants.update_all update_clause.join(', ')
+        unscoped_descendants_before_save.update_all update_clause.join(', ')
       end
     end
   end

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -32,6 +32,8 @@ class ArrangementTest < ActiveSupport::TestCase
   end
 
   def test_update_descendants_with_changed_parent_value
+    return if Ancestry.default_update_strategy == :sql # sql stragery doesn't trigger callbacks
+
     AncestryTestDatabase.with_model(
       extra_columns: { name: :string, name_path: :string }
     ) do |model|

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -31,6 +31,42 @@ class ArrangementTest < ActiveSupport::TestCase
     end
   end
 
+  def test_update_descendants_with_changed_parent_value
+    AncestryTestDatabase.with_model(
+      extra_columns: { name: :string, name_path: :string }
+    ) do |model|
+
+      model.class_eval do
+        before_save :update_name_path
+
+        def update_name_path
+          self.name_path = [parent&.name_path, name].compact.join('/')
+        end
+      end
+
+      m1 = model.create!( name: "parent" )
+      m2 = model.create( parent: m1, name: "child" )
+      m3 = model.create( parent: m2, name: "grandchild" )
+      m4 = model.create( parent: m3, name: "grandgrandchild" )
+      assert_equal([m1.id], m2.ancestor_ids)
+      assert_equal("parent", m1.reload.name_path)
+      assert_equal("parent/child", m2.reload.name_path)
+      assert_equal("parent/child/grandchild", m3.reload.name_path)
+      assert_equal("parent/child/grandchild/grandgrandchild", m4.reload.name_path)
+
+      m5 = model.create!( name: "changed" )
+
+      m2.update!( parent_id: m5.id )
+      assert_equal("changed", m5.reload.name_path)
+      assert_equal([m5.id], m2.reload.ancestor_ids)
+      assert_equal("changed/child", m2.reload.name_path)
+      assert_equal([m5.id,m2.id], m3.reload.ancestor_ids)
+      assert_equal("changed/child/grandchild", m3.reload.name_path)
+      assert_equal([m5.id,m2.id,m3.id], m4.reload.ancestor_ids)
+      assert_equal("changed/child/grandchild/grandgrandchild", m4.reload.name_path)
+    end
+  end
+
   def test_has_ancestry_detects_changes_in_after_save
     AncestryTestDatabase.with_model(:extra_columns => {:name => :string, :name_path => :string}) do |model|
       model.class_eval do


### PR DESCRIPTION
This simple code will not work as expected when you update a parent's slug - descendants won't have the slug changed.
```
class Model
  before_save :update_slug

  def update_slug
    self.slug = [parent.slug, self.slug].join('/')
  end
end
```

That is because `update_descendants_with_new_ancestry` is run with `before_save` and the `parent` method loads an unchanged version from the database.
This PR moves `update_descendants_with_new_ancestry` to `after_update`.

There's no tests for such case right now, but I've tested it with my code and it works. Testing with `update_strategy = :sql` would be appreciated, though the change is pretty simple and should just work.