### PR TITLE
Fix materialized_path2

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           # for this database, run all the forms of our tests
           bundle exec rake
-          STRATEGY=materialized_path2 bundle exec rake
+          FORMAT=materialized_path2 bundle exec rake
 
       - name: run pg tests
         env:
@@ -95,8 +95,8 @@ jobs:
           # db container is currently creating the database
           # psql -c 'create database ancestry_test;' || echo 'db exists'
           bundle exec rake
+          FORMAT=materialized_path2 bundle exec rake
 
-          STRATEGY=materialized_path2 bundle exec rake
       - name: run mysql tests
         env:
           DB: mysql2
@@ -111,5 +111,4 @@ jobs:
           # db container is currently creating the database
           # mysql --host $MYSQL_HOST --port 3306 -u $MYSQL_USER  -e 'CREATE SCHEMA IF NOT EXISTS 'ancestry_test';'
           bundle exec rake
-
-          STRATEGY=materialized_path2 bundle exec rake
+          FORMAT=materialized_path2 bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Doing our best at supporting [SemVer](http://semver.org/) with
 a nice looking [Changelog](http://keepachangelog.com).
 
+## Version [4.3.0] <sub><sup>2023-01-05</sub></sup>
+* Fix: materialized_path2 strategy was completely broken [#597](https://github.com/stefankroes/ancestry/pull/597) (thx @kshnurov)
+* Fix: descendants ancestry should be updated in after_update callbacks [#589](https://github.com/stefankroes/ancestry/pull/589) (thx @kshnurov)
+
 ## Version [4.2.0] <sub><sup>2022-06-09</sub></sup>
 
 * added strategy: materialized_path2 [#571](https://github.com/stefankroes/ancestry/pull/571)
@@ -270,7 +274,8 @@ Missed 2 commits (which are feature adds)
 * Validations
 
 
-[HEAD]: https://github.com/stefankroes/ancestry/compare/v4.2.0...HEAD
+[HEAD]: https://github.com/stefankroes/ancestry/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/stefankroes/ancestry/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/stefankroes/ancestry/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/stefankroes/ancestry/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/stefankroes/ancestry/compare/v3.2.1...v4.0.0

--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -4,6 +4,7 @@ require_relative 'ancestry/instance_methods'
 require_relative 'ancestry/exceptions'
 require_relative 'ancestry/has_ancestry'
 require_relative 'ancestry/materialized_path'
+require_relative 'ancestry/materialized_path2'
 require_relative 'ancestry/materialized_path_pg'
 
 I18n.load_path += Dir[File.join(File.expand_path(File.dirname(__FILE__)),

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -48,7 +48,7 @@ module Ancestry
 
       attribute self.ancestry_column, default: self.ancestry_root
 
-      validates self.ancestry_column, self.ancestry_validation_options
+      validates self.ancestry_column, ancestry_validation_options
 
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
       include Ancestry::MaterializedPathPg if update_strategy == :sql

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -4,14 +4,24 @@ module Ancestry
       # Check options
       raise Ancestry::AncestryException.new(I18n.t("ancestry.option_must_be_hash")) unless options.is_a? Hash
       options.each do |key, value|
-        unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :touch, :counter_cache, :primary_key_format, :update_strategy, :strategy].include? key
+        unless [:ancestry_column, :orphan_strategy, :cache_depth, :depth_cache_column, :touch, :counter_cache, :primary_key_format, :update_strategy, :ancestry_format].include? key
           raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_option", key: key.inspect, value: value.inspect))
         end
+      end
+
+      if options[:ancestry_format].present? && ![:materialized_path, :materialized_path2].include?( options[:ancestry_format] )
+        raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_format", value: options[:ancestry_format]))
       end
 
       # Create ancestry column accessor and set to option or default
       cattr_accessor :ancestry_column
       self.ancestry_column = options[:ancestry_column] || :ancestry
+
+      cattr_accessor :ancestry_primary_key_format
+      self.ancestry_primary_key_format = options[:primary_key_format].presence || '[0-9]+'
+
+      cattr_accessor :ancestry_delimiter
+      self.ancestry_delimiter = '/'
 
       # Save self as base class (for STI)
       cattr_accessor :ancestry_base_class
@@ -27,13 +37,18 @@ module Ancestry
       # Include dynamic class methods
       extend Ancestry::ClassMethods
 
-      if options[:strategy] == :materialized_path2
-        validates_format_of self.ancestry_column, :with => derive_materialized2_pattern(options[:primary_key_format]), :allow_nil => false
+      cattr_accessor :ancestry_format
+      self.ancestry_format = options[:ancestry_format] || :materialized_path
+
+      if options[:ancestry_format] == :materialized_path2
         extend Ancestry::MaterializedPath2
       else
-        validates_format_of self.ancestry_column, :with => derive_materialized_pattern(options[:primary_key_format]), :allow_nil => true
         extend Ancestry::MaterializedPath
       end
+
+      attribute self.ancestry_column, default: self.ancestry_root
+
+      validates self.ancestry_column, self.ancestry_validation_options
 
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
       include Ancestry::MaterializedPathPg if update_strategy == :sql
@@ -98,28 +113,6 @@ module Ancestry
     def acts_as_tree(*args)
       return super if defined?(super)
       has_ancestry(*args)
-    end
-
-    private
-
-    def derive_materialized_pattern(primary_key_format, delimiter = '/')
-      primary_key_format ||= '[0-9]+'
-
-      if primary_key_format.to_s.include?('\A')
-        primary_key_format
-      else
-        /\A#{primary_key_format}(#{delimiter}#{primary_key_format})*\Z/
-      end
-    end
-
-    def derive_materialized2_pattern(primary_key_format, delimiter = '/')
-      primary_key_format ||= '[0-9]+'
-
-      if primary_key_format.to_s.include?('\A')
-        primary_key_format
-      else
-        /\A#{delimiter}(#{primary_key_format}#{delimiter})*\Z/
-      end
     end
   end
 end

--- a/lib/ancestry/locales/en.yml
+++ b/lib/ancestry/locales/en.yml
@@ -9,6 +9,7 @@ en:
 
     option_must_be_hash: "Options for has_ancestry must be in a hash."
     unknown_option: "Unknown option for has_ancestry: %{key} => %{value}."
+    unknown_format: "Unknown ancestry format: %{value}."
     named_scope_depth_cache: "Named scope '%{scope_name}' is only available when depth caching is enabled."
 
     exclude_self: "%{class_name} cannot be a descendant of itself."

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -1,24 +1,19 @@
 module Ancestry
   # store ancestry as /grandparent_id/parent_id/
-  # root: a=/,id=1    children=a.id/% == /1/%
-  # 3:    a=/1/2/,id=3 children=a.id/% == /1/2/3/%
-  module MaterializedPath2 < MaterializedPath
+  # root: a=/,id=1    children=#{a}#{id}/% == /1/%
+  # 3:    a=/1/2/,id=3 children=#{a}#{id}/% == /1/2/3/%
+  module MaterializedPath2
+    include MaterializedPath
+
+    def self.extended(base)
+      base.send(:include, MaterializedPath::InstanceMethods)
+      base.send(:include, InstanceMethods)
+    end
+
     def indirects_of(object)
       t = arel_table
       node = to_node(object)
-      where(t[ancestry_column].matches("#{node.child_ancestry}%#{ANCESTRY_DELIMITER}%", nil, true))
-    end
-
-    def subtree_of(object)
-      t = arel_table
-      node = to_node(object)
-      where(descendant_conditions(node).or(t[primary_key].eq(node.id)))
-    end
-
-    def siblings_of(object)
-      t = arel_table
-      node = to_node(object)
-      where(t[ancestry_column].eq(node[ancestry_column]))
+      where(t[ancestry_column].matches("#{node.child_ancestry}%#{ancestry_delimiter}%", nil, true))
     end
 
     def ordered_by_ancestry(order = nil)
@@ -26,32 +21,42 @@ module Ancestry
     end
 
     def descendants_by_ancestry(ancestry)
-      arel_table[ancestry_column].matches("#{ancestry}/%", nil, true)
+      arel_table[ancestry_column].matches("#{ancestry}%", nil, true)
+    end
+
+    def ancestry_root
+      ancestry_delimiter
+    end
+
+    private
+
+    def ancestry_nil_allowed?
+      false
+    end
+
+    def ancestry_format_regexp
+      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_primary_key_format}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
     end
 
     module InstanceMethods
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        path_was = self.send("#{self.ancestry_base_class.ancestry_column}#{IN_DATABASE_SUFFIX}")
-        "#{path_was}#{id}#{ANCESTRY_DELIMITER}"
+        "#{attribute_in_database(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        path_was = self.send("#{self.ancestry_base_class.ancestry_column}#{BEFORE_LAST_SAVE_SUFFIX}")
-        "#{path_was}#{id}#{ANCESTRY_DELIMITER}"
-      end
-
-      def parse_ancestry_column(obj)
-        return [] if obj == ROOT
-        obj_ids = obj.split(ANCESTRY_DELIMITER).delete_if(&:blank?)
-        self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
+        "#{attribute_before_last_save(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
       end
 
       def generate_ancestry(ancestor_ids)
-        "#{ANCESTRY_DELIMITER}#{ancestor_ids.join(ANCESTRY_DELIMITER)}#{ANCESTRY_DELIMITER}"
+        if ancestor_ids.present? && ancestor_ids.any?
+          "#{self.ancestry_base_class.ancestry_delimiter}#{ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)}#{self.ancestry_base_class.ancestry_delimiter}"
+        else
+          self.ancestry_base_class.ancestry_root
+        end
       end
     end
   end

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -5,15 +5,15 @@ module Ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
         ancestry_column = ancestry_base_class.ancestry_column
-        old_ancestry = path_ids_before_last_save.join(Ancestry::MaterializedPath::ANCESTRY_DELIMITER)
-        new_ancestry = path_ids.join(Ancestry::MaterializedPath::ANCESTRY_DELIMITER)
+        old_ancestry = generate_ancestry( path_ids_before_last_save )
+        new_ancestry = generate_ancestry( path_ids )
         update_clause = [
-          "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{old_ancestry}', '#{new_ancestry}')"
+          "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
         if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
           depth_cache_column = ancestry_base_class.depth_cache_column.to_s
-          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{old_ancestry}', '#{new_ancestry}'), '\\d', '', 'g')) + 1"
+          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/lib/ancestry/version.rb
+++ b/lib/ancestry/version.rb
@@ -1,3 +1,3 @@
 module Ancestry
-  VERSION = '4.2.0'
+  VERSION = '4.3.0'
 end

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -129,16 +129,29 @@ class ArrangementTest < ActiveSupport::TestCase
 
   def test_arrange_serializable
     AncestryTestDatabase.with_model :depth => 2, :width => 2 do |model, _roots|
-      result = [{"ancestry"=>nil,
-          "id"=>4,
-          "children"=>
-           [{"ancestry"=>"4", "id"=>6, "children"=>[]},
-            {"ancestry"=>"4", "id"=>5, "children"=>[]}]},
-         {"ancestry"=>nil,
-          "id"=>1,
-          "children"=>
-           [{"ancestry"=>"1", "id"=>3, "children"=>[]},
-            {"ancestry"=>"1", "id"=>2, "children"=>[]}]}]
+      if model.ancestry_format == :materialized_path2
+        result = [{"ancestry"=>'/',
+            "id"=>4,
+            "children"=>
+            [{"ancestry"=>"/4/", "id"=>6, "children"=>[]},
+              {"ancestry"=>"/4/", "id"=>5, "children"=>[]}]},
+          {"ancestry"=>'/',
+            "id"=>1,
+            "children"=>
+            [{"ancestry"=>"/1/", "id"=>3, "children"=>[]},
+              {"ancestry"=>"/1/", "id"=>2, "children"=>[]}]}]
+      else
+        result = [{"ancestry"=>nil,
+            "id"=>4,
+            "children"=>
+            [{"ancestry"=>"4", "id"=>6, "children"=>[]},
+              {"ancestry"=>"4", "id"=>5, "children"=>[]}]},
+          {"ancestry"=>nil,
+            "id"=>1,
+            "children"=>
+            [{"ancestry"=>"1", "id"=>3, "children"=>[]},
+              {"ancestry"=>"1", "id"=>2, "children"=>[]}]}]
+      end
 
       assert_equal model.arrange_serializable(order: "id desc"), result
     end

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -85,7 +85,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(false, m1.modified)
+      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
       assert_equal(true, m2.modified)
     end
   end
@@ -106,7 +106,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(false, m1.modified)
+      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
       assert_equal(true, m2.modified)
     end
   end

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -83,7 +83,11 @@ class OphanStrategiesTest < ActiveSupport::TestCase
       assert_equal(model.find(n3.id).parent,n1, "orphan's not parentified" )
       assert_equal(model.find(n5.id).ancestor_ids, [n1.id,n4.id], "ancestry integrity not maintained")
       n1.destroy                          # delete a root node with desecendants
-      assert_nil(model.find(n3.id).ancestry," new root node has no empty ancestry string")
+      if model.ancestry_format == :materialized_path2
+        assert_equal(model.find(n3.id).ancestry, model.ancestry_root, " new root node has no root ancestry string")
+      else
+        assert_nil(model.find(n3.id).ancestry," new root node has no empty ancestry string")
+      end
       assert_equal(model.find(n3.id).valid?, true, " new root node is not valid")
       assert_nil(model.find(n3.id).parent_id, " Children of the deleted root not rootfied")
       assert_equal(model.find(n5.id).ancestor_ids, [n4.id], "ancestry integrity not maintained")

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -4,11 +4,22 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation
     AncestryTestDatabase.with_model do |model|
       node = model.create
-      ['3', '10/2', '1/4/30', nil].each do |value|
+      if model.ancestry_format == :materialized_path2
+        vals = ['/3/', '/10/2/', '/1/4/30/', model.ancestry_root]
+      else
+        vals = ['3', '10/2', '1/4/30', model.ancestry_root]
+      end
+      vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
-      ['a', 'a/b', '-34'].each do |value|
+
+      if model.ancestry_format == :materialized_path2
+        vals = ['/a/', '/a/b/', '/-34/']
+      else
+        vals = ['a', 'a/b', '-34']
+      end
+      vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert !node.errors[model.ancestry_column].blank?
       end
@@ -18,17 +29,27 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation_alt
     AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/) do |model|
       node = model.create(:id => 'z')
-      ['a', 'a/b', 'a/b/c', nil].each do |value|
+      if model.ancestry_format == :materialized_path2
+        vals = ['/a/', '/a/b/', '/a/b/c/', model.ancestry_root]
+      else
+        vals = ['a', 'a/b', 'a/b/c', model.ancestry_root]
+      end
+      vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
-      ['1', '1/2', 'a-b/c'].each do |value|
+
+      if model.ancestry_format == :materialized_path2
+        vals = ['/1/', '/1/2/', '/a-b/c/']
+      else
+        vals = ['1', '1/2', 'a-b/c']
+      end
+      vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
         node.valid?; assert !node.errors[model.ancestry_column].blank?
       end
     end
   end
-
 
   def test_ancestry_validation_exclude_self
     AncestryTestDatabase.with_model do |model|

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -74,7 +74,7 @@ class AncestryTestDatabase
     width                = options.delete(:width) || 0
     extra_columns        = options.delete(:extra_columns)
     default_scope_params = options.delete(:default_scope_params)
-    options[:strategy]   = ENV["STRATEGY"] if ENV["STRATEGY"].present?
+    options[:ancestry_format]   = ENV["FORMAT"].to_sym if ENV["FORMAT"].present?
 
     table_options={}
     table_options[:id] = options.delete(:id) if options.key?(:id)


### PR DESCRIPTION
materialized_path2 was completely broken [from the beginning](https://github.com/stefankroes/ancestry/pull/571#issuecomment-1245091316).
This PR fixes it and renames `strategy` to `ancestry_format` since it's not really a strategy, it doesn't change any behavior.