### PR TITLE
Refactor options storage

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module ClassMethods
     # Fetch tree node if necessary
     def to_node object
-      if object.is_a?(self.ancestry_base_class)
+      if object.is_a?(ancestry_base_class)
         object
       else
         unscoped_where { |scope| scope.find(object.try(primary_key) || object) }
@@ -11,7 +11,7 @@ module Ancestry
 
     # Scope on relative depth options
     def scope_depth depth_options, depth
-      depth_options.inject(self.ancestry_base_class) do |scope, option|
+      depth_options.inject(ancestry_base_class) do |scope, option|
         scope_name, relative_depth = option
         if [:before_depth, :to_depth, :at_depth, :from_depth, :after_depth].include? scope_name
           scope.send scope_name, depth + relative_depth
@@ -29,9 +29,9 @@ module Ancestry
     # Get all nodes and sort them into an empty hash
     def arrange options = {}
       if (order = options.delete(:order))
-        arrange_nodes self.ancestry_base_class.order(order).where(options)
+        arrange_nodes ancestry_base_class.order(order).where(options)
       else
-        arrange_nodes self.ancestry_base_class.where(options)
+        arrange_nodes ancestry_base_class.where(options)
       end
     end
 
@@ -158,7 +158,7 @@ module Ancestry
     def restore_ancestry_integrity!
       parent_ids = {}
       # Wrap the whole thing in a transaction ...
-      self.ancestry_base_class.transaction do
+      ancestry_base_class.transaction do
         unscoped_where do |scope|
           # For each node ...
           scope.find_each do |node|
@@ -210,7 +210,7 @@ module Ancestry
     def rebuild_depth_cache!
       raise Ancestry::AncestryException.new(I18n.t("ancestry.cannot_rebuild_depth_cache")) unless ancestry_options[:cache_depth]
 
-      self.ancestry_base_class.transaction do
+      ancestry_base_class.transaction do
         unscoped_where do |scope|
           scope.find_each do |node|
             node.update_attribute ancestry_options[:depth_cache_column], node.depth
@@ -220,7 +220,7 @@ module Ancestry
     end
 
     def unscoped_where
-      yield self.ancestry_base_class.default_scoped.unscope(:where)
+      yield ancestry_base_class.default_scoped.unscope(:where)
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -119,7 +119,7 @@ module Ancestry
             if !node.sane_ancestor_ids?
               raise Ancestry::AncestryIntegrityException.new(I18n.t("ancestry.invalid_ancestry_column",
                                                                     node_id: node.id,
-                                                                    ancestry_column: "#{node.read_attribute node.ancestry_base_class.ancestry_column}"
+                                                                    ancestry_column: "#{node.read_attribute node.class.ancestry_column}"
                                                                     ))
             end
             # ... check that all ancestors exist

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -39,7 +39,7 @@ module Ancestry
 
       # Save self as base class (for STI)
       self.class_variable_set('@@ancestry_base_class', self)
-      cattr_reader :ancestry_base_class
+      cattr_reader :ancestry_base_class, instance_reader: false
 
       # Include instance methods
       include Ancestry::InstanceMethods

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -13,23 +13,33 @@ module Ancestry
         raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_format", value: options[:ancestry_format]))
       end
 
+      if options[:orphan_strategy].present? && ![:rootify, :adopt, :restrict, :destroy].include?(options[:orphan_strategy])
+        raise Ancestry::AncestryException.new(I18n.t("ancestry.invalid_orphan_strategy"))
+      end
+
       # Create ancestry column accessor and set to option or default
-      cattr_accessor :ancestry_column
-      self.ancestry_column = options[:ancestry_column] || :ancestry
+      self.class_variable_set('@@ancestry_column', options[:ancestry_column] || :ancestry)
+      cattr_reader :ancestry_column, instance_reader: false
 
-      cattr_accessor :ancestry_primary_key_format
-      self.ancestry_primary_key_format = options[:primary_key_format].presence || '[0-9]+'
+      self.class_variable_set('@@ancestry_options', {
+        primary_key_format: options[:primary_key_format].presence || '[0-9]+',
+        touch: options[:touch] || false,
+        ancestry_format: options[:ancestry_format] || :materialized_path,
+        cache_depth: options[:cache_depth] || false,
+        depth_cache_column: options[:depth_cache_column] || :ancestry_depth,
+        counter_cache: options[:counter_cache],
+        counter_cache_column: options[:counter_cache] == true ? :children_count : options[:counter_cache],
+        update_strategy: options[:update_strategy] || Ancestry.default_update_strategy,
+        orphan_strategy: options[:orphan_strategy] || :destroy,
+      }.freeze)
+      cattr_reader :ancestry_options, instance_reader: false
 
-      cattr_accessor :ancestry_delimiter
-      self.ancestry_delimiter = '/'
+      self.class_variable_set('@@ancestry_delimiter', '/')
+      cattr_reader :ancestry_delimiter, instance_reader: false
 
       # Save self as base class (for STI)
-      cattr_accessor :ancestry_base_class
-      self.ancestry_base_class = self
-
-      # Touch ancestors after updating
-      cattr_accessor :touch_ancestors
-      self.touch_ancestors = options[:touch] || false
+      self.class_variable_set('@@ancestry_base_class', self)
+      cattr_reader :ancestry_base_class
 
       # Include instance methods
       include Ancestry::InstanceMethods
@@ -37,25 +47,18 @@ module Ancestry
       # Include dynamic class methods
       extend Ancestry::ClassMethods
 
-      cattr_accessor :ancestry_format
-      self.ancestry_format = options[:ancestry_format] || :materialized_path
-
-      if options[:ancestry_format] == :materialized_path2
+      if ancestry_options[:ancestry_format] == :materialized_path2
         extend Ancestry::MaterializedPath2
       else
         extend Ancestry::MaterializedPath
       end
 
       attribute self.ancestry_column, default: self.ancestry_root
-
       validates self.ancestry_column, ancestry_validation_options
 
-      update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
-      include Ancestry::MaterializedPathPg if update_strategy == :sql
-
-      # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
-      cattr_reader :orphan_strategy
-      self.orphan_strategy = options[:orphan_strategy] || :destroy
+      if ancestry_options[:update_strategy] == :sql
+        include Ancestry::MaterializedPathPg
+      end
 
       # Validate that the ancestor ids don't include own id
       validate :ancestry_exclude_self
@@ -67,29 +70,17 @@ module Ancestry
       before_destroy :apply_orphan_strategy
 
       # Create ancestry column accessor and set to option or default
-      if options[:cache_depth]
-        # Create accessor for column name and set to option or default
-        self.cattr_accessor :depth_cache_column
-        self.depth_cache_column = options[:depth_cache_column] || :ancestry_depth
-
+      if ancestry_options[:cache_depth]
         # Cache depth in depth cache column before save
         before_validation :cache_depth
         before_save :cache_depth
 
         # Validate depth column
-        validates_numericality_of depth_cache_column, :greater_than_or_equal_to => 0, :only_integer => true, :allow_nil => false
+        validates_numericality_of ancestry_options[:depth_cache_column], greater_than_or_equal_to: 0, only_integer: true, allow_nil: false
       end
 
       # Create counter cache column accessor and set to option or default
-      if options[:counter_cache]
-        cattr_accessor :counter_cache_column
-
-        if options[:counter_cache] == true
-          self.counter_cache_column = :children_count
-        else
-          self.counter_cache_column = options[:counter_cache]
-        end
-
+      if ancestry_options[:counter_cache]
         after_create :increase_parent_counter_cache, if: :has_parent?
         after_destroy :decrease_parent_counter_cache, if: :has_parent?
         after_update :update_parent_counter_cache
@@ -100,8 +91,8 @@ module Ancestry
         scope scope_name, lambda { |depth|
           raise Ancestry::AncestryException.new(I18n.t("ancestry.named_scope_depth_cache",
                                                        :scope_name => scope_name
-                                                       )) unless options[:cache_depth]
-          where("#{depth_cache_column} #{operator} ?", depth)
+                                                       )) unless ancestry_options[:cache_depth]
+          where("#{ancestry_options[:depth_cache_column]} #{operator} ?", depth)
         }
       end
 

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -63,7 +63,7 @@ module Ancestry
     # Counter Cache
     def increase_parent_counter_cache
       return unless parent_id
-      self.ancestry_base_class.increment_counter self.class.ancestry_options[:counter_cache_column], parent_id
+      self.class.ancestry_base_class.increment_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def decrease_parent_counter_cache
@@ -75,14 +75,14 @@ module Ancestry
       return if defined?(@_trigger_destroy_callback) && !@_trigger_destroy_callback
       return if ancestry_callbacks_disabled?
 
-      self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id
+      self.class.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def update_parent_counter_cache
       return unless saved_change_to_attribute?(self.class.ancestry_column)
 
       if parent_id_was = parent_id_before_last_save
-        self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id_was
+        self.class.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id_was
       end
 
       increase_parent_counter_cache
@@ -120,8 +120,8 @@ module Ancestry
     end
 
     def ancestors depth_options = {}
-      return self.ancestry_base_class.none unless has_parent?
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
+      return self.class.none unless has_parent?
+      self.class.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
     end
 
     def path_ids
@@ -133,7 +133,7 @@ module Ancestry
     end
 
     def path depth_options = {}
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
+      self.class.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
     end
 
     def depth
@@ -203,7 +203,7 @@ module Ancestry
     # Children
 
     def children
-      self.ancestry_base_class.children_of(self)
+      self.class.ancestry_base_class.children_of(self)
     end
 
     def child_ids
@@ -227,7 +227,7 @@ module Ancestry
     # Siblings
 
     def siblings
-      self.ancestry_base_class.siblings_of(self)
+      self.class.ancestry_base_class.siblings_of(self)
     end
 
     # NOTE: includes self
@@ -252,7 +252,7 @@ module Ancestry
     # Descendants
 
     def descendants depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
     end
 
     def descendant_ids depth_options = {}
@@ -266,7 +266,7 @@ module Ancestry
     # Indirects
 
     def indirects depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
     end
 
     def indirect_ids depth_options = {}
@@ -280,7 +280,7 @@ module Ancestry
     # Subtree
 
     def subtree depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
     end
 
     def subtree_ids depth_options = {}
@@ -303,13 +303,13 @@ module Ancestry
   private
     def unscoped_descendants
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_conditions(self)
+        scope.where self.class.ancestry_base_class.descendant_conditions(self)
       end
     end
 
     def unscoped_descendants_before_save
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_before_save_conditions(self)
+        scope.where self.class.ancestry_base_class.descendant_before_save_conditions(self)
       end
     end
 
@@ -327,7 +327,7 @@ module Ancestry
     end
 
     def unscoped_where
-      self.ancestry_base_class.unscoped_where do |scope|
+      self.class.ancestry_base_class.unscoped_where do |scope|
         yield scope
       end
     end

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -106,7 +106,7 @@ module Ancestry
     end
 
     def ancestry_format_regexp
-      /\A#{ancestry_primary_key_format}(#{Regexp.escape(ancestry_delimiter)}#{ancestry_primary_key_format})*\z/.freeze
+      /\A#{ancestry_options[:primary_key_format]}(#{Regexp.escape(ancestry_delimiter)}#{ancestry_options[:primary_key_format]})*\z/.freeze
     end
 
     module InstanceMethods

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -112,29 +112,29 @@ module Ancestry
     module InstanceMethods
       # optimization - better to go directly to column and avoid parsing
       def ancestors?
-        read_attribute(self.ancestry_base_class.ancestry_column) != self.ancestry_base_class.ancestry_root
+        read_attribute(self.class.ancestry_column) != self.class.ancestry_root
       end
       alias :has_parent? :ancestors?
 
       def ancestor_ids=(value)
-        write_attribute(self.ancestry_base_class.ancestry_column, generate_ancestry(value))
+        write_attribute(self.class.ancestry_column, generate_ancestry(value))
       end
 
       def ancestor_ids
-        parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(read_attribute(self.class.ancestry_column))
       end
 
       def ancestor_ids_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
       end
 
       def parent_id_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column)).last
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column)).last
       end
 
       # optimization - better to go directly to column and avoid parsing
       def sibling_of?(node)
-        self.read_attribute(self.ancestry_base_class.ancestry_column) == node.read_attribute(self.ancestry_base_class.ancestry_column)
+        self.read_attribute(self.class.ancestry_column) == node.read_attribute(node.class.ancestry_column)
       end
 
       # private (public so class methods can find it)
@@ -143,26 +143,26 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_in_database(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_in_database(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_before_last_save(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_before_last_save(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def parse_ancestry_column(obj)
-        return [] if obj.nil? || obj == self.ancestry_base_class.ancestry_root
-        obj_ids = obj.split(self.ancestry_base_class.ancestry_delimiter).delete_if(&:blank?)
+        return [] if obj.nil? || obj == self.class.ancestry_root
+        obj_ids = obj.split(self.class.ancestry_delimiter).delete_if(&:blank?)
         self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)
+          ancestor_ids.join(self.class.ancestry_delimiter)
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -35,7 +35,7 @@ module Ancestry
     end
 
     def ancestry_format_regexp
-      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_primary_key_format}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
+      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_options[:primary_key_format]}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
     end
 
     module InstanceMethods

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -42,20 +42,20 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_in_database(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_in_database(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_before_last_save(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          "#{self.ancestry_base_class.ancestry_delimiter}#{ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)}#{self.ancestry_base_class.ancestry_delimiter}"
+          "#{self.class.ancestry_delimiter}#{ancestor_ids.join(self.class.ancestry_delimiter)}#{self.class.ancestry_delimiter}"
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -11,9 +11,8 @@ module Ancestry
           "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
-        if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
-          depth_cache_column = ancestry_base_class.depth_cache_column.to_s
-          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
+        if ancestry_base_class.ancestry_options[:cache_depth] && respond_to?(ancestry_base_class.ancestry_options[:depth_cache_column])
+          update_clause << "#{ancestry_base_class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -4,15 +4,14 @@ module Ancestry
     def update_descendants_with_new_ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
-        ancestry_column = ancestry_base_class.ancestry_column
         old_ancestry = generate_ancestry( path_ids_before_last_save )
         new_ancestry = generate_ancestry( path_ids )
         update_clause = [
-          "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
+          "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
-        if ancestry_base_class.ancestry_options[:cache_depth] && respond_to?(ancestry_base_class.ancestry_options[:depth_cache_column])
-          update_clause << "#{ancestry_base_class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
+        if self.class.ancestry_options[:cache_depth] && respond_to?(self.class.ancestry_options[:depth_cache_column])
+          update_clause << "#{self.class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{self.class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -129,7 +129,7 @@ class ArrangementTest < ActiveSupport::TestCase
 
   def test_arrange_serializable
     AncestryTestDatabase.with_model :depth => 2, :width => 2 do |model, _roots|
-      if model.ancestry_format == :materialized_path2
+      if model.ancestry_options[:ancestry_format] == :materialized_path2
         result = [{"ancestry"=>'/',
             "id"=>4,
             "children"=>

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -13,15 +13,6 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
-  def test_setting_ancestry_column
-    AncestryTestDatabase.with_model do |model|
-      model.ancestry_column = :ancestors
-      assert_equal :ancestors, model.ancestry_column
-      model.ancestry_column = :ancestry
-      assert_equal :ancestry, model.ancestry_column
-    end
-  end
-
   def test_invalid_has_ancestry_options
     assert_raise Ancestry::AncestryException do
       Class.new(ActiveRecord::Base).has_ancestry :this_option_doesnt_exist => 42

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -85,7 +85,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
+      assert_equal(model.ancestry_options[:ancestry_format] == :materialized_path2 ? true : false, m1.modified)
       assert_equal(true, m2.modified)
     end
   end
@@ -106,7 +106,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
+      assert_equal(model.ancestry_options[:ancestry_format] == :materialized_path2 ? true : false, m1.modified)
       assert_equal(true, m2.modified)
     end
   end

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -4,7 +4,7 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation
     AncestryTestDatabase.with_model do |model|
       node = model.create
-      if model.ancestry_format == :materialized_path2
+      if model.ancestry_options[:ancestry_format] == :materialized_path2
         vals = ['/3/', '/10/2/', '/1/4/30/', model.ancestry_root]
       else
         vals = ['3', '10/2', '1/4/30', model.ancestry_root]
@@ -14,7 +14,7 @@ class ValidationsTest < ActiveSupport::TestCase
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
 
-      if model.ancestry_format == :materialized_path2
+      if model.ancestry_options[:ancestry_format] == :materialized_path2
         vals = ['/a/', '/a/b/', '/-34/']
       else
         vals = ['a', 'a/b', '-34']
@@ -29,7 +29,7 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation_alt
     AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/) do |model|
       node = model.create(:id => 'z')
-      if model.ancestry_format == :materialized_path2
+      if model.ancestry_options[:ancestry_format] == :materialized_path2
         vals = ['/a/', '/a/b/', '/a/b/c/', model.ancestry_root]
       else
         vals = ['a', 'a/b', 'a/b/c', model.ancestry_root]
@@ -39,7 +39,7 @@ class ValidationsTest < ActiveSupport::TestCase
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
 
-      if model.ancestry_format == :materialized_path2
+      if model.ancestry_options[:ancestry_format] == :materialized_path2
         vals = ['/1/', '/1/2/', '/a-b/c/']
       else
         vals = ['1', '1/2', 'a-b/c']


### PR DESCRIPTION
All writers are removed (you shouldn't change ancestry options on-the-fly, that'll lead to unexpected behavior) and all instance accessors are removed.
We do not mention `ancestry_column` or `ancestry_delimiter` accessors in the docs, but if someone is using them this will be a breaking change for them.
Since this is an internal API, I'm not sure if we should bump a major version. What do you think?