### PR TITLE
Document and test with column collation

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -83,7 +83,6 @@ jobs:
       - name: run pg tests
         env:
           DB: pg
-          COLLATE_SYMBOLS: false
         run: |
           COUNT=1
           while ! pg_isready ; do

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -52,12 +52,8 @@ class ScopesTest < ActiveSupport::TestCase
   def test_order_by
     AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, _roots|
       # Some pg databases do not use symbols in sorting
-      # if this is failing, try running the test via DB=pg COLLATE_SYMBOLS=false rake test
-      if ENV["COLLATE_SYMBOLS"].to_s =~ /false/i
-        expected = model.all.sort_by { |m| [m.ancestor_ids.map(&:to_s).join, m.id.to_i] }
-      else
-        expected = model.all.sort_by { |m| [m.ancestor_ids.map(&:to_s), m.id.to_i] }
-      end
+      # if this is failing, try tweaking the collation of your ancestry columns
+      expected = model.all.sort_by { |m| [m.ancestor_ids.map(&:to_s), m.id.to_i] }
       actual = model.ordered_by_ancestry_and(:id)
       assert_equal (expected.map { |r| [r.ancestor_ids, r.id.to_s] }), (actual.map { |r| [r.ancestor_ids, r.id.to_s] })
     end

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -56,7 +56,7 @@ class AncestryTestDatabase
 
       # This only affects postgres
       # the :ruby code path will get tested in mysql and sqlite3
-      Ancestry.default_update_strategy = :sql if db_type == "pg"
+      Ancestry.default_update_strategy = :sql if postgres?
 
     rescue => err
       if ENV["CI"]
@@ -128,6 +128,9 @@ class AncestryTestDatabase
     else; []; end
   end
 
+  def self.postgres?
+    db_type == "pg"
+  end
   private
 
   def self.db_type


### PR DESCRIPTION
Add documentation and tests for users to set collation on the `ancestry` column.

We need to encourage users to use a binary/ascii collation for the `ancestry` column otherwise they and loosing the main benefit of materialized path, specifically the fact that we use an index for `ancestry LIKE '$ancestry/%'`.

I'm hoping we can drop `ENV["ANCESTRY_COLLATION"]` which is there because canonical ignores punctuation when sorting/comparing strings. Getting us to use the proper indexes means all systems will behave in a more consistent manner.
