### PR TITLE
Add default ancestry format and primary key format

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -12,6 +12,8 @@ I18n.load_path += Dir[File.join(File.expand_path(File.dirname(__FILE__)),
 
 module Ancestry
   @@default_update_strategy = :ruby
+  @@default_ancestry_format = :materialized_path2
+  @@default_primary_key_format = '[0-9]+'
 
   # @!default_update_strategy
   #   @return [Symbol] the default strategy for updating ancestry
@@ -27,12 +29,46 @@ module Ancestry
   #
   #        Child records are updated in sql and callbacks will not get called.
   #        Associated records in memory will have the wrong ancestry value
-
   def self.default_update_strategy
     @@default_update_strategy
   end
 
   def self.default_update_strategy=(value)
     @@default_update_strategy = value
+  end
+
+  # @!default_ancestry_format
+  #   @return [Symbol] the default strategy for updating ancestry
+  #
+  # The value changes the default way that ancestry is stored in the database
+  #
+  #    :materialized_path (default and legacy)
+  #
+  #        Ancestry is of the form null (for no ancestors) and 1/2/ for children
+  #
+  #    :materialized_path2 (preferred)
+  #
+  #        Ancestry is of the form '/' (for no ancestors) and '/1/2/' for children
+  def self.default_ancestry_format
+    @@default_ancestry_format
+  end
+
+  def self.default_ancestry_format=(value)
+    @@default_ancestry_format = value
+  end
+
+  # @!default_primary_key_format
+  #   @return [Symbol] the regular expression representing the primary key
+  #
+  # The value represents the way the id looks for validation
+  #
+  #    '[0-9]+' (default) for integer ids
+  #    '[-A-Fa-f0-9]{36}'    for uuids (though you can find other regular expressions)
+  def self.default_primary_key_format
+    @@default_primary_key_format
+  end
+
+  def self.default_primary_key_format=(value)
+    @@default_primary_key_format = value
   end
 end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -18,7 +18,7 @@ module Ancestry
       self.ancestry_column = options[:ancestry_column] || :ancestry
 
       cattr_accessor :ancestry_primary_key_format
-      self.ancestry_primary_key_format = options[:primary_key_format].presence || '[0-9]+'
+      self.ancestry_primary_key_format = options[:primary_key_format].presence || Ancestry.default_primary_key_format
 
       cattr_accessor :ancestry_delimiter
       self.ancestry_delimiter = '/'
@@ -38,9 +38,9 @@ module Ancestry
       extend Ancestry::ClassMethods
 
       cattr_accessor :ancestry_format
-      self.ancestry_format = options[:ancestry_format] || :materialized_path
+      self.ancestry_format = options[:ancestry_format] || Ancestry.default_update_strategy
 
-      if options[:ancestry_format] == :materialized_path2
+      if ancestry_format == :materialized_path2
         extend Ancestry::MaterializedPath2
       else
         extend Ancestry::MaterializedPath

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -57,6 +57,7 @@ class AncestryTestDatabase
       # This only affects postgres
       # the :ruby code path will get tested in mysql and sqlite3
       Ancestry.default_update_strategy = :sql if postgres?
+      Ancestry.default_ancestry_format = ENV["FORMAT"].to_sym if ENV["FORMAT"].present?
 
     rescue => err
       if ENV["CI"]
@@ -86,7 +87,6 @@ class AncestryTestDatabase
     width                = options.delete(:width) || 0
     extra_columns        = options.delete(:extra_columns)
     default_scope_params = options.delete(:default_scope_params)
-    options[:ancestry_format]   = ENV["FORMAT"].to_sym if ENV["FORMAT"].present?
 
     table_options={}
     table_options[:id] = options.delete(:id) if options.key?(:id)


### PR DESCRIPTION
These tend to be the same across a whole database.

The primary key format is used for databases with uuids for the primary key The ancestry format makes it easy for a new user to get up and running using a different ancestry encoding format