### PR TITLE
Default ancestry format to materialized_path

### DIFF
--- a/lib/ancestry.rb
+++ b/lib/ancestry.rb
@@ -12,7 +12,7 @@ I18n.load_path += Dir[File.join(File.expand_path(File.dirname(__FILE__)),
 
 module Ancestry
   @@default_update_strategy = :ruby
-  @@default_ancestry_format = :materialized_path2
+  @@default_ancestry_format = :materialized_path
   @@default_primary_key_format = '[0-9]+'
 
   # @!default_update_strategy

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -38,7 +38,7 @@ module Ancestry
       extend Ancestry::ClassMethods
 
       cattr_accessor :ancestry_format
-      self.ancestry_format = options[:ancestry_format] || Ancestry.default_update_strategy
+      self.ancestry_format = options[:ancestry_format] || Ancestry.default_ancestry_format
 
       if ancestry_format == :materialized_path2
         extend Ancestry::MaterializedPath2


### PR DESCRIPTION
Wish we did not have to do this,
but for now, to avoid breaking changes, defaulting to the legacy format

Fixes bug introduced in #612 