### PR TITLE
Drop Orphan strategy class attribute

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -21,17 +21,6 @@ module Ancestry
       end
     end
 
-    # Orphan strategy writer
-    def orphan_strategy= orphan_strategy
-      # Check value of orphan strategy, only rootify, adopt, restrict or destroy is allowed
-      if [:rootify, :adopt, :restrict, :destroy].include? orphan_strategy
-        class_variable_set :@@orphan_strategy, orphan_strategy
-      else
-        raise Ancestry::AncestryException.new(I18n.t("ancestry.invalid_orphan_strategy"))
-      end
-    end
-
-
     # these methods arrange an entire subtree into nested hashes for easy navigation after database retrieval
     # the arrange method also works on a scoped class
     # the arrange method takes ActiveRecord find options

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -13,6 +13,11 @@ module Ancestry
         raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_format", value: options[:ancestry_format]))
       end
 
+      orphan_strategy = options[:orphan_strategy] || :destroy
+      if ![:rootify, :adopt, :restrict, :destroy].include?(orphan_strategy)
+        raise Ancestry::AncestryException.new(I18n.t("ancestry.invalid_orphan_strategy"))
+      end
+
       # Create ancestry column accessor and set to option or default
       cattr_accessor :ancestry_column
       self.ancestry_column = options[:ancestry_column] || :ancestry
@@ -53,9 +58,9 @@ module Ancestry
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
       include Ancestry::MaterializedPathPg if update_strategy == :sql
 
-      # Create orphan strategy accessor and set to option or default (writer comes from DynamicClassMethods)
+      # set orphan strategy
       cattr_reader :orphan_strategy
-      self.orphan_strategy = options[:orphan_strategy] || :destroy
+      class_variable_set :@@orphan_strategy, orphan_strategy
 
       # Validate that the ancestor ids don't include own id
       validate :ancestry_exclude_self

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -8,31 +8,21 @@ class OphanStrategiesTest < ActiveSupport::TestCase
   end
 
   def test_non_default_orphan_strategy
-    AncestryTestDatabase.with_model :orphan_strategy => :rootify do |model|
+    AncestryTestDatabase.with_model orphan_strategy: :rootify do |model|
       assert_equal :rootify, model.orphan_strategy
-    end
-  end
-
-  def test_setting_orphan_strategy
-    AncestryTestDatabase.with_model do |model|
-      model.orphan_strategy = :rootify
-      assert_equal :rootify, model.orphan_strategy
-      model.orphan_strategy = :destroy
-      assert_equal :destroy, model.orphan_strategy
     end
   end
 
   def test_setting_invalid_orphan_strategy
-    AncestryTestDatabase.with_model do |model|
+    AncestryTestDatabase.with_model skip_ancestry: true do |model|
       assert_raise Ancestry::AncestryException do
-        model.orphan_strategy = :non_existent_orphan_strategy
+        model.has_ancestry orphan_strategy: :non_existent_orphan_strategy
       end
     end
   end
 
   def test_orphan_rootify_strategy
-    AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
-      model.orphan_strategy = :rootify
+    AncestryTestDatabase.with_model orphan_strategy: :rootify, :depth => 3, :width => 3 do |model, roots|
       root = roots.first.first
       children = root.children.to_a
       root.destroy
@@ -45,8 +35,7 @@ class OphanStrategiesTest < ActiveSupport::TestCase
   end
 
   def test_orphan_destroy_strategy
-    AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
-      model.orphan_strategy = :destroy
+    AncestryTestDatabase.with_model orphan_strategy: :destroy, :depth => 3, :width => 3 do |model, roots|
       root = roots.first.first
       assert_difference 'model.count', -root.subtree.size do
         root.destroy
@@ -59,8 +48,7 @@ class OphanStrategiesTest < ActiveSupport::TestCase
   end
 
   def test_orphan_restrict_strategy
-    AncestryTestDatabase.with_model :depth => 3, :width => 3 do |model, roots|
-      model.orphan_strategy = :restrict
+    AncestryTestDatabase.with_model orphan_strategy: :restrict, :depth => 3, :width => 3 do |model, roots|
       root = roots.first.first
       assert_raise Ancestry::AncestryException do
         root.destroy
@@ -72,8 +60,7 @@ class OphanStrategiesTest < ActiveSupport::TestCase
   end
 
   def test_orphan_adopt_strategy
-    AncestryTestDatabase.with_model do |model|
-      model.orphan_strategy = :adopt  # set the orphan strategy as paerntify
+    AncestryTestDatabase.with_model orphan_strategy: :adopt do |model|
       n1 = model.create!                  #create a root node
       n2 = model.create!(:parent => n1)   #create child with parent=root
       n3 = model.create!(:parent => n2)   #create child with parent=n2, depth = 2

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -1,18 +1,6 @@
 require_relative '../environment'
 
 class OphanStrategiesTest < ActiveSupport::TestCase
-  def test_default_orphan_strategy
-    AncestryTestDatabase.with_model do |model|
-      assert_equal :destroy, model.orphan_strategy
-    end
-  end
-
-  def test_non_default_orphan_strategy
-    AncestryTestDatabase.with_model orphan_strategy: :rootify do |model|
-      assert_equal :rootify, model.orphan_strategy
-    end
-  end
-
   def test_setting_invalid_orphan_strategy
     AncestryTestDatabase.with_model skip_ancestry: true do |model|
       assert_raise Ancestry::AncestryException do


### PR DESCRIPTION
This is part of a push to remove so much global state stored in the class.
Some parts pulled from #600 

`orphan_strategy` getters and setters on the class were never part of the public API but necessary for an internal implementation. Removing this internal mechanism that has potentially leaked to external implementations.

Currently the supported usage pattern for `orphan_strategy` is still:

```ruby
class Model < ActiveRecord::Base
  has_ancestry orphan_strategy: :destroy
end
```

Dropping accessing and changing the value directly in the class:

```ruby
class Model < ActiveRecord::Base
  has_ancestry
  # removing: self.orphan_strategy = :destroy
  # removing: puts "changed to #{orphan_strategy}"
end
```

---

I did go through github and no projects using ancestry referenced `orphan_strategy` or `orphan_strategy=`.

A number of the projects did call `has_ancestry` with `:orphan_strategy`, as well as `acts_as_tree`. Which is good. that means this feature is in use and those projects only use the public api.
