### PR TITLE
Drop ancestry_base_class

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module ClassMethods
     # Fetch tree node if necessary
     def to_node object
-      if object.is_a?(self.ancestry_base_class)
+      if object.is_a?(self.base_class)
         object
       else
         unscoped_where { |scope| scope.find(object.try(primary_key) || object) }
@@ -11,7 +11,7 @@ module Ancestry
 
     # Scope on relative depth options
     def scope_depth depth_options, depth
-      depth_options.inject(self.ancestry_base_class) do |scope, option|
+      depth_options.inject(self.base_class) do |scope, option|
         scope_name, relative_depth = option
         if [:before_depth, :to_depth, :at_depth, :from_depth, :after_depth].include? scope_name
           scope.send scope_name, depth + relative_depth
@@ -40,9 +40,9 @@ module Ancestry
     # Get all nodes and sort them into an empty hash
     def arrange options = {}
       if (order = options.delete(:order))
-        arrange_nodes self.ancestry_base_class.order(order).where(options)
+        arrange_nodes self.base_class.order(order).where(options)
       else
-        arrange_nodes self.ancestry_base_class.where(options)
+        arrange_nodes self.base_class.where(options)
       end
     end
 
@@ -175,7 +175,7 @@ module Ancestry
     def restore_ancestry_integrity!
       parent_ids = {}
       # Wrap the whole thing in a transaction ...
-      self.ancestry_base_class.transaction do
+      self.base_class.transaction do
         unscoped_where do |scope|
           # For each node ...
           scope.find_each do |node|
@@ -227,7 +227,7 @@ module Ancestry
     def rebuild_depth_cache!
       raise Ancestry::AncestryException.new(I18n.t("ancestry.cannot_rebuild_depth_cache")) unless respond_to? :depth_cache_column
 
-      self.ancestry_base_class.transaction do
+      self.base_class.transaction do
         unscoped_where do |scope|
           scope.find_each do |node|
             node.update_attribute depth_cache_column, node.depth
@@ -237,7 +237,7 @@ module Ancestry
     end
 
     def unscoped_where
-      yield self.ancestry_base_class.default_scoped.unscope(:where)
+      yield self.base_class.default_scoped.unscope(:where)
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -23,10 +23,6 @@ module Ancestry
       cattr_accessor :ancestry_delimiter
       self.ancestry_delimiter = '/'
 
-      # Save self as base class (for STI)
-      cattr_accessor :ancestry_base_class
-      self.ancestry_base_class = self
-
       # Touch ancestors after updating
       cattr_accessor :touch_ancestors
       self.touch_ancestors = options[:touch] || false

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -23,7 +23,7 @@ module Ancestry
     # Apply orphan strategy (before destroy - no changes)
     def apply_orphan_strategy
       if !ancestry_callbacks_disabled? && !new_record?
-        case self.ancestry_base_class.orphan_strategy
+        case self.class.base_class.orphan_strategy
         when :rootify # make all children root if orphan strategy is rootify
           unscoped_descendants.each do |descendant|
             descendant.without_ancestry_callbacks do
@@ -50,7 +50,7 @@ module Ancestry
 
     # Touch each of this record's ancestors (after save)
     def touch_ancestors_callback
-      if !ancestry_callbacks_disabled? && self.ancestry_base_class.touch_ancestors
+      if !ancestry_callbacks_disabled? && self.class.base_class.touch_ancestors
         # Touch each of the old *and* new ancestors
         unscoped_current_and_previous_ancestors.each do |ancestor|
           ancestor.without_ancestry_callbacks do
@@ -62,7 +62,7 @@ module Ancestry
 
     # Counter Cache
     def increase_parent_counter_cache
-      self.ancestry_base_class.increment_counter _counter_cache_column, parent_id
+      self.class.base_class.increment_counter _counter_cache_column, parent_id
     end
 
     def decrease_parent_counter_cache
@@ -74,7 +74,7 @@ module Ancestry
       return if defined?(@_trigger_destroy_callback) && !@_trigger_destroy_callback
       return if ancestry_callbacks_disabled?
 
-      self.ancestry_base_class.decrement_counter _counter_cache_column, parent_id
+      self.class.base_class.decrement_counter _counter_cache_column, parent_id
     end
 
     def update_parent_counter_cache
@@ -83,14 +83,14 @@ module Ancestry
       return unless changed
 
       if parent_id_was = parent_id_before_last_save
-        self.ancestry_base_class.decrement_counter _counter_cache_column, parent_id_was
+        self.class.base_class.decrement_counter _counter_cache_column, parent_id_was
       end
 
-      parent_id && self.ancestry_base_class.increment_counter(_counter_cache_column, parent_id)
+      parent_id && self.class.base_class.increment_counter(_counter_cache_column, parent_id)
     end
 
     def _counter_cache_column
-      self.ancestry_base_class.counter_cache_column.to_s
+      self.class.base_class.counter_cache_column.to_s
     end
 
     # Ancestors
@@ -125,8 +125,8 @@ module Ancestry
     end
 
     def ancestors depth_options = {}
-      return self.ancestry_base_class.none unless has_parent?
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
+      return self.class.base_class.none unless has_parent?
+      self.class.base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
     end
 
     def path_ids
@@ -138,7 +138,7 @@ module Ancestry
     end
 
     def path depth_options = {}
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
+      self.class.base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
     end
 
     def depth
@@ -146,7 +146,7 @@ module Ancestry
     end
 
     def cache_depth
-      write_attribute self.ancestry_base_class.depth_cache_column, depth
+      write_attribute self.class.base_class.depth_cache_column, depth
     end
 
     def ancestor_of?(node)
@@ -208,7 +208,7 @@ module Ancestry
     # Children
 
     def children
-      self.ancestry_base_class.children_of(self)
+      self.class.base_class.children_of(self)
     end
 
     def child_ids
@@ -232,7 +232,7 @@ module Ancestry
     # Siblings
 
     def siblings
-      self.ancestry_base_class.siblings_of(self)
+      self.class.base_class.siblings_of(self)
     end
 
     # NOTE: includes self
@@ -257,7 +257,7 @@ module Ancestry
     # Descendants
 
     def descendants depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
+      self.class.base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
     end
 
     def descendant_ids depth_options = {}
@@ -271,7 +271,7 @@ module Ancestry
     # Indirects
 
     def indirects depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
+      self.class.base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
     end
 
     def indirect_ids depth_options = {}
@@ -285,7 +285,7 @@ module Ancestry
     # Subtree
 
     def subtree depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
+      self.class.base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
     end
 
     def subtree_ids depth_options = {}
@@ -308,13 +308,13 @@ module Ancestry
   private
     def unscoped_descendants
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_conditions(self)
+        scope.where self.class.base_class.descendant_conditions(self)
       end
     end
 
     def unscoped_descendants_before_save
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_before_save_conditions(self)
+        scope.where self.class.base_class.descendant_before_save_conditions(self)
       end
     end
 
@@ -332,7 +332,7 @@ module Ancestry
     end
 
     def unscoped_where
-      self.ancestry_base_class.unscoped_where do |scope|
+      self.class.base_class.unscoped_where do |scope|
         yield scope
       end
     end

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -78,7 +78,7 @@ module Ancestry
     end
 
     def update_parent_counter_cache
-      changed = saved_change_to_attribute?(self.ancestry_base_class.ancestry_column)
+      changed = saved_change_to_attribute?(self.class.ancestry_column)
 
       return unless changed
 
@@ -101,7 +101,7 @@ module Ancestry
     alias :ancestors? :has_parent?
 
     def ancestry_changed?
-      column = self.ancestry_base_class.ancestry_column.to_s
+      column = self.class.ancestry_column.to_s
         # These methods return nil if there are no changes.
         # This was fixed in a refactoring in rails 6.0: https://github.com/rails/rails/pull/35933
         !!(will_save_change_to_attribute?(column) || saved_change_to_attribute?(column))
@@ -111,7 +111,7 @@ module Ancestry
       current_context, self.validation_context = validation_context, nil
       errors.clear
 
-      attribute = ancestry_base_class.ancestry_column
+      attribute = self.class.ancestry_column
       ancestry_value = send(attribute)
       return true unless ancestry_value
 
@@ -212,7 +212,7 @@ module Ancestry
     end
 
     def child_ids
-      children.pluck(self.ancestry_base_class.primary_key)
+      children.pluck(self.class.primary_key)
     end
 
     def has_children?
@@ -237,7 +237,7 @@ module Ancestry
 
     # NOTE: includes self
     def sibling_ids
-      siblings.pluck(self.ancestry_base_class.primary_key)
+      siblings.pluck(self.class.primary_key)
     end
 
     def has_siblings?
@@ -261,7 +261,7 @@ module Ancestry
     end
 
     def descendant_ids depth_options = {}
-      descendants(depth_options).pluck(self.ancestry_base_class.primary_key)
+      descendants(depth_options).pluck(self.class.primary_key)
     end
 
     def descendant_of?(node)
@@ -275,7 +275,7 @@ module Ancestry
     end
 
     def indirect_ids depth_options = {}
-      indirects(depth_options).pluck(self.ancestry_base_class.primary_key)
+      indirects(depth_options).pluck(self.class.primary_key)
     end
 
     def indirect_of?(node)
@@ -289,7 +289,7 @@ module Ancestry
     end
 
     def subtree_ids depth_options = {}
-      subtree(depth_options).pluck(self.ancestry_base_class.primary_key)
+      subtree(depth_options).pluck(self.class.primary_key)
     end
 
     # Callback disabling

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -112,29 +112,29 @@ module Ancestry
     module InstanceMethods
       # optimization - better to go directly to column and avoid parsing
       def ancestors?
-        read_attribute(self.ancestry_base_class.ancestry_column) != self.ancestry_base_class.ancestry_root
+        read_attribute(self.class.ancestry_column) != self.class.ancestry_root
       end
       alias :has_parent? :ancestors?
 
       def ancestor_ids=(value)
-        write_attribute(self.ancestry_base_class.ancestry_column, generate_ancestry(value))
+        write_attribute(self.class.ancestry_column, generate_ancestry(value))
       end
 
       def ancestor_ids
-        parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(read_attribute(self.class.ancestry_column))
       end
 
       def ancestor_ids_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
       end
 
       def parent_id_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column)).last
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column)).last
       end
 
       # optimization - better to go directly to column and avoid parsing
       def sibling_of?(node)
-        self.read_attribute(self.ancestry_base_class.ancestry_column) == node.read_attribute(self.ancestry_base_class.ancestry_column)
+        self.read_attribute(self.class.ancestry_column) == node.read_attribute(self.class.ancestry_column)
       end
 
       # private (public so class methods can find it)
@@ -143,26 +143,26 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_in_database(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_in_database(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_before_last_save(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_before_last_save(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def parse_ancestry_column(obj)
-        return [] if obj.nil? || obj == self.ancestry_base_class.ancestry_root
-        obj_ids = obj.split(self.ancestry_base_class.ancestry_delimiter).delete_if(&:blank?)
+        return [] if obj.nil? || obj == self.class.ancestry_root
+        obj_ids = obj.split(self.class.ancestry_delimiter).delete_if(&:blank?)
         self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)
+          ancestor_ids.join(self.class.ancestry_delimiter)
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -42,20 +42,20 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_in_database(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_in_database(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_before_last_save(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          "#{self.ancestry_base_class.ancestry_delimiter}#{ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)}#{self.ancestry_base_class.ancestry_delimiter}"
+          "#{self.class.ancestry_delimiter}#{ancestor_ids.join(self.class.ancestry_delimiter)}#{self.class.ancestry_delimiter}"
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -4,16 +4,15 @@ module Ancestry
     def update_descendants_with_new_ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
-        ancestry_column = ancestry_base_class.ancestry_column
         old_ancestry = generate_ancestry( path_ids_before_last_save )
         new_ancestry = generate_ancestry( path_ids )
         update_clause = [
-          "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
+          "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
         if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
           depth_cache_column = ancestry_base_class.depth_cache_column.to_s
-          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
+          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -10,9 +10,9 @@ module Ancestry
           "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
-        if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
-          depth_cache_column = ancestry_base_class.depth_cache_column.to_s
-          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
+        if self.class.base_class.respond_to?(:depth_cache_column) && respond_to?(self.class.base_class.depth_cache_column)
+          depth_cache_column = self.class.base_class.depth_cache_column.to_s
+          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{self.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/test/concerns/sti_support_test.rb
+++ b/test/concerns/sti_support_test.rb
@@ -51,7 +51,7 @@ class StiSupportTest < ActiveSupport::TestCase
 
       # children
 
-      assert_equal [child], root.children.order(:id) # missing model_child
+      assert_equal [child, model_child], root.children.order(:id)
       assert_equal root, child.parent
       assert_equal root, model_child.parent
 

--- a/test/concerns/sti_support_test.rb
+++ b/test/concerns/sti_support_test.rb
@@ -26,13 +26,37 @@ class StiSupportTest < ActiveSupport::TestCase
     end
   end
 
+  # not sure that we need to support his case
   def test_sti_support_with_from_subclass
-    AncestryTestDatabase.with_model :extra_columns => {:type => :string} do |model|
+    AncestryTestDatabase.with_model :ancestry_column => :t1,
+                                    :counter_cache => true,
+                                    :extra_columns => {:type => :string} do |model|
       subclass1 = Object.const_set 'SubclassWithAncestry', Class.new(model)
-      subclass1.has_ancestry
-      subclass1.create!
+      subclass2 = Object.const_set 'SubclassOfSubclassWithAncestry', Class.new(model)
+
+      # we are defining it one level below the parent ("model" class)
+      subclass1.has_ancestry :ancestry_column => :t1, :counter_cache => true
+
+      # if ancestry is not propogated, then create will fail
+
+      root = subclass1.create!
+      # this was the line that was blowing up for this orginal feature
+      child = subclass1.create(:parent => root)
+      # not sure that this should work (spoiler: it does)
+      model_child = model.create(:parent => root)
+
+      # counter caches across class lines (going up to parent)
+
+      assert_equal 2, root.reload.children_count
+
+      # children
+
+      assert_equal [child], root.children.order(:id) # missing model_child
+      assert_equal root, child.parent
+      assert_equal root, model_child.parent
 
       Object.send :remove_const, 'SubclassWithAncestry'
+      Object.send :remove_const, 'SubclassOfSubclassWithAncestry'
     end
   end
 


### PR DESCRIPTION
active_record defines base_class as the top of an STI tree.

ancestry had a similar concept. It was the class where ancestry was defined.
Since ancestry originally called it a base_class,
there was a conflict and in 4e57f32e1758 it was renamed to ancestry_base_class
 
PRs of note:
- #86
- #87

The ancestry_base_class is used quite often to make sure the proper class
is accessed to lookup values.

I'm not sure the use case for defining ancestry in the middle of a hierarchy,
but it doesn't seem to work in a reasonable manner. (UPDATE: the tests were faulty. I'm fixing the tests so it is properly tested)

```
class  Class1 < ActiveRecord:Base
end
class Class2 < Class1
  has_ancestry counter_cache: :child_count
end

root = Class2.create!
node = root.children.create!

root.children == []
node.root == root
root.child_count == 0
```

I'm dropping this custom concept and using the standard rails concept
instead, as I think it should have been done originally.

---

Contemplating raising an error if a developer adds `has_ancestry` to a non `base_class`.