### PR TITLE
fix changelog line [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ a nice looking [Changelog](http://keepachangelog.com).
 * Documented column collation and testing [#601](https://github.com/stefankroes/ancestry/pull/601) [#607](https://github.com/stefankroes/ancestry/pull/607) (thx @kshnurov)
 * Added initializer with default_ancestry_format [#612](https://github.com/stefankroes/ancestry/pull/612) [#613](https://github.com/stefankroes/ancestry/pull/613)
 * ruby 3.2 support [#596](https://github.com/stefankroes/ancestry/pull/596) (thx @petergoldstein)
-* arrange is 3x faster and uses 20-30x less memory [#415](https://github.com/stefankroes/ancestry/pull/415)
+* Reduce memory for sort_by_ancestry [#415](https://github.com/stefankroes/ancestry/pull/415)
 
 ## Version [4.2.0] <sub><sup>2022-06-09</sub></sup>
 


### PR DESCRIPTION
It was pointed out in #622 that `sort_by_ancestry` was updated and `arrange` was not.

Thank you @kshnurov 