### PR TITLE
Tests more closely follow suggested configurations

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -37,19 +37,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # this matrix is driven by these sources:
+        # - https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+        # - https://www.ruby-lang.org/en/downloads/branches/
+        # - https://guides.rubyonrails.org/maintenance_policy.html
+        format: [materialized_path, materialized_path2]
+        activerecord: [70]
+        ruby: [3.1, 3.2]
+        # additional tests
         include:
+          # EOL 6/2022
           - ruby: 2.5
             activerecord: 52
+          # EOL 2023
           - ruby: 2.7
             activerecord: 60
+          # rails 6.1 and 7.0 have different ruby versions
           - ruby: 2.7
             activerecord: 61
           - ruby: "3.0"
             activerecord: 61
-          - ruby: 3.1
-            activerecord: 70
-          - ruby: 3.2
-            activerecord: 70
     env:
       # for the pg cli (psql, pg_isready) and possibly rails
       PGHOST: 127.0.0.1 # container is mapping it locally
@@ -67,47 +74,35 @@ jobs:
 
       - name: setup Ruby
         # https://github.com/ruby/setup-ruby#versioning
+        # runs 'bundle install' and caches installed gems automatically
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
 
       - name: run sqlite tests
         env:
           DB: sqlite3
         run: |
-          # for this database, run all the forms of our tests
-          bundle exec rake
-          FORMAT=materialized_path2 bundle exec rake
-
+          FORMAT=${{ matrix.format }} bundle exec rake
       - name: run pg tests
         env:
           DB: pg
         run: |
-          COUNT=1
-          while ! pg_isready ; do
-            echo "waiting for postgres to start"
-            COUNT=$(($COUNT + 1))
-            [[ $COUNT -lt 20 ]] || break
-            sleep 1
-          done
-          # db container is currently creating the database
-          # psql -c 'create database ancestry_test;' || echo 'db exists'
-          bundle exec rake
-          FORMAT=materialized_path2 bundle exec rake
+          FORMAT=${{ matrix.format }} bundle exec rake
+      - name: run pg tests (UPDATE_STRATEGY=sql)
+        env:
+          DB: pg
+        run: |
+          FORMAT=${{ matrix.format }} UPDATE_STRATEGY=sql bundle exec rake
 
       - name: run mysql tests
         env:
           DB: mysql2
         run: |
-          COUNT=1
-          while ! mysqladmin ping -h $MYSQL_HOST -P3306 --silent ; do
-            echo "waiting for mysql to start"
-            COUNT=$(($COUNT + 1))
-            [[ $COUNT -lt 20 ]] || break
-            sleep 1
-          done
-          # db container is currently creating the database
-          # mysql --host $MYSQL_HOST --port 3306 -u $MYSQL_USER  -e 'CREATE SCHEMA IF NOT EXISTS 'ancestry_test';'
-          bundle exec rake
-          FORMAT=materialized_path2 bundle exec rake
+          FORMAT=${{ matrix.format }} bundle exec rake
+      - name: run mysql tests (ANCESTRY_COLUMN_TYPE=binary)
+        env:
+          DB: mysql2
+        run: |
+          FORMAT=${{ matrix.format }} ANCESTRY_COLUMN_TYPE=binary bundle exec rake

--- a/test/concerns/arrangement_test.rb
+++ b/test/concerns/arrangement_test.rb
@@ -129,7 +129,7 @@ class ArrangementTest < ActiveSupport::TestCase
 
   def test_arrange_serializable
     AncestryTestDatabase.with_model :depth => 2, :width => 2 do |model, _roots|
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         result = [{"ancestry"=>'/',
             "id"=>4,
             "children"=>

--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -85,7 +85,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
+      assert_equal(AncestryTestDatabase.materialized_path2?, m1.modified)
       assert_equal(true, m2.modified)
     end
   end
@@ -106,7 +106,7 @@ class ArrangementTest < ActiveSupport::TestCase
       m2 = model.create!(:parent => m1, :name => "child")
       m2.parent = nil
       m2.save!
-      assert_equal(model.ancestry_format == :materialized_path2 ? true : false, m1.modified)
+      assert_equal(AncestryTestDatabase.materialized_path2?, m1.modified)
       assert_equal(true, m2.modified)
     end
   end

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -58,7 +58,7 @@ class OphanStrategiesTest < ActiveSupport::TestCase
       assert_equal(model.find(n3.id).parent,n1, "orphan's not parentified" )
       assert_equal(model.find(n5.id).ancestor_ids, [n1.id,n4.id], "ancestry integrity not maintained")
       n1.destroy                          # delete a root node with desecendants
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         assert_equal(model.find(n3.id).ancestry, model.ancestry_root, " new root node has no root ancestry string")
       else
         assert_nil(model.find(n3.id).ancestry," new root node has no empty ancestry string")

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -4,7 +4,7 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation
     AncestryTestDatabase.with_model do |model|
       node = model.create
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         vals = ['/3/', '/10/2/', '/1/4/30/', model.ancestry_root]
       else
         vals = ['3', '10/2', '1/4/30', model.ancestry_root]
@@ -14,7 +14,7 @@ class ValidationsTest < ActiveSupport::TestCase
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
 
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         vals = ['/a/', '/a/b/', '/-34/']
       else
         vals = ['a', 'a/b', '-34']
@@ -29,7 +29,7 @@ class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation_alt
     AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/) do |model|
       node = model.create(:id => 'z')
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         vals = ['/a/', '/a/b/', '/a/b/c/', model.ancestry_root]
       else
         vals = ['a', 'a/b', 'a/b/c', model.ancestry_root]
@@ -39,7 +39,7 @@ class ValidationsTest < ActiveSupport::TestCase
         node.valid?; assert node.errors[model.ancestry_column].blank?
       end
 
-      if model.ancestry_format == :materialized_path2
+      if AncestryTestDatabase.materialized_path2?
         vals = ['/1/', '/1/2/', '/a-b/c/']
       else
         vals = ['1', '1/2', 'a-b/c']

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -150,6 +150,11 @@ class AncestryTestDatabase
   def self.postgres?
     db_type == "pg"
   end
+
+  def self.materialized_path2?
+    return @materialized_path2 if defined?(@materialized_path2)
+    @materialized_path2 = (ENV["FORMAT"] == "materialized_path2")
+  end
   private
 
   def self.db_type


### PR DESCRIPTION
## Test both `materialized_path`

~~I hadn't noticed that #597 dropped all the `materialized_path` testing.
Since a majority of the users are using `materialized_path`, we need to make sure this is working front and foremost~~

Setting the column to `nulls: true` only for `materialized_path`

## Separate update mode

### Before

We were testing postgres only with `:sql` update mode.

### After

This behavior has not changed. But now it is more explicit.

It seems fine to only test postgres with `:sql` update mode since
both mysql and sqlite paths are testing the traditional `:ruby` update mode.

## Test mysql with binary columns

Running mysql with both ascii and binary columns since we support both.

## Support matrix

- https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
- https://www.ruby-lang.org/en/downloads/branches/
- https://guides.rubyonrails.org/maintenance_policy.html

Rails 5.2 and 6.0 (and the corresponding ruby 2.5 to 2.7) are basically EOL. Lets keep them until they hold us back.

Due to the way I've setup the matrix, I need to choose a single rails version to test with 7.0. I chose 2.2 since that is rail's suggested version.

This leaves us not testing ruby 2.3. If anyone knows how to add both 2.2 and 2.3, please share.

