### PR TITLE
[4.3.x] Deprecate adding ancestry to the middle of an STI tree

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -1,9 +1,9 @@
 name: run-test-suite
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 4-3-stable ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 4-3-stable ]
 
 jobs:
   test:

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -1,6 +1,11 @@
 module Ancestry
   module HasAncestry
     def has_ancestry options = {}
+
+      if base_class != self
+        ActiveSupport::Deprecation.warn("Please move has_ancestry to the root of the STI inheritance tree.")
+      end
+
       # Check options
       raise Ancestry::AncestryException.new(I18n.t("ancestry.option_must_be_hash")) unless options.is_a? Hash
       options.each do |key, value|

--- a/test/concerns/sti_support_test.rb
+++ b/test/concerns/sti_support_test.rb
@@ -36,8 +36,10 @@ class StiSupportTest < ActiveSupport::TestCase
       subclass1 = Object.const_set 'SubclassWithAncestry', Class.new(model)
       subclass2 = Object.const_set 'SubclassOfSubclassWithAncestry', Class.new(subclass1)
 
-      # we are defining it one level below the parent ("model" class)
-      subclass1.has_ancestry :ancestry_column => :t1, :counter_cache => true
+      ActiveSupport::Deprecation.silence do
+        # we are defining it one level below the parent ("model" class)
+        subclass1.has_ancestry :ancestry_column => :t1, :counter_cache => true
+      end
 
       # if ancestry is not propogated, then create will fail
 

--- a/test/concerns/sti_support_test.rb
+++ b/test/concerns/sti_support_test.rb
@@ -26,13 +26,37 @@ class StiSupportTest < ActiveSupport::TestCase
     end
   end
 
+  # not sure that we need to support this case
+  # where we are creating a tree in the middle of a model
   def test_sti_support_with_from_subclass
-    AncestryTestDatabase.with_model :extra_columns => {:type => :string} do |model|
+    AncestryTestDatabase.with_model :ancestry_column => :t1,
+                                    :skip_ancestry => true,
+                                    :counter_cache => true,
+                                    :extra_columns => {:type => :string} do |model|
       subclass1 = Object.const_set 'SubclassWithAncestry', Class.new(model)
-      subclass1.has_ancestry
-      subclass1.create!
+      subclass2 = Object.const_set 'SubclassOfSubclassWithAncestry', Class.new(subclass1)
+
+      # we are defining it one level below the parent ("model" class)
+      subclass1.has_ancestry :ancestry_column => :t1, :counter_cache => true
+
+      # if ancestry is not propogated, then create will fail
+
+      root = subclass1.create!
+      # this was the line that was blowing up for this orginal feature
+      child = subclass1.create!(:parent => root)
+      child2 = subclass2.create!(:parent => root)
+
+      # counter caches across class lines (going up to parent)
+
+      assert_equal 2, root.reload.children_count
+
+      # children
+
+      assert_equal [child, child2], root.children.order(:id)
+      assert_equal root, child.parent
 
       Object.send :remove_const, 'SubclassWithAncestry'
+      Object.send :remove_const, 'SubclassOfSubclassWithAncestry'
     end
   end
 


### PR DESCRIPTION
Added deprecation warnings for `has_ancestry` in the middle of an STI tree.

---

Still haven't thought up a good use case for why someone would define ancestry in the middle of an STI tree.

Due to the way it was introduce, it is possible that allowing `has_ancestry` in the middle of the tree was not an explicit goal but a side effect.

This warning will go into 4.3.x. Unsure if we will drop this functionality in 5.0 or 6.0.

The test helper has an implicit `has_ancestry` at the top level so it was masking the intent of the test. Whether we deprecate the feature or not, it is best to get this test into the code.

NOTE: as follow up, need to add deprecation for #617 but it looks like that may be invasive. may want to backport that PR and tweak it