### PR TITLE
Root node has no siblings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The yellow nodes are those returned by the method.
 
 When using `STI` all classes are returned from the scopes unless you specify otherwise using `where(:type => "ChildClass")`.
 
-<sup id="fn1">1. [other root records are considered siblings]<a href="#ref1" title="Jump back to footnote 1.">↩</a></sup>
+<sup id="fn1">1. [other root records are not considered siblings]<a href="#ref1" title="Jump back to footnote 1.">↩</a></sup>
 
 # has_ancestry options
 

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -68,7 +68,11 @@ module Ancestry
     def siblings_of(object)
       t = arel_table
       node = to_node(object)
-      where(t[ancestry_column].eq(node[ancestry_column].presence))
+      if node[ancestry_column] == ancestry_root
+        none
+      else
+        where(t[ancestry_column].eq(node[ancestry_column].presence))
+      end
     end
 
     def ordered_by_ancestry(order = nil)

--- a/test/concerns/scopes_test.rb
+++ b/test/concerns/scopes_test.rb
@@ -6,9 +6,9 @@ class ScopesTest < ActiveSupport::TestCase
       # Roots assertion
       assert_equal roots.map(&:first).sort, model.roots.to_a.sort
 
-      # All roots are root's siblings (want to change this)
+      # roots have no siblings
       a_root = roots.first.first
-      assert_equal model.siblings_of(a_root).sort, roots.map(&:first).sort
+      assert model.siblings_of(a_root).empty?
 
       model.all.each do |test_node|
         # Assertions for ancestors_of named scope

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -24,10 +24,10 @@ class TreeNavigationTest < ActiveSupport::TestCase
         assert lvl0_node.has_children?
         assert !lvl0_node.is_childless?
         # Siblings assertions
-        assert_equal roots.map(&:first).map(&:id), lvl0_node.sibling_ids
-        assert_equal roots.map(&:first), lvl0_node.siblings
-        assert lvl0_node.has_siblings?
-        assert !lvl0_node.is_only_child?
+        assert lvl0_node.sibling_ids.empty?
+        assert lvl0_node.siblings.empty?
+        refute lvl0_node.has_siblings?
+        assert lvl0_node.is_only_child?
         # Descendants assertions
         descendants = model.all.find_all do |node|
           node.ancestor_ids.include? lvl0_node.id

--- a/test/concerns/tree_predicate_test.rb
+++ b/test/concerns/tree_predicate_test.rb
@@ -23,8 +23,8 @@ class TreePredicateTest < ActiveSupport::TestCase
         assert children.map { |n| !root.child_of?(n) }.all?
         assert children.map { |n| n.child_of?(root) }.all?
         # Siblings assertions
-        assert root.has_siblings?
-        assert !root.is_only_child?
+        refute root.has_siblings?
+        assert root.is_only_child?
         assert children.map { |n| !n.is_only_child? }.all?
         assert children.map { |n| !root.sibling_of?(n) }.all?
         assert children.permutation(2).map { |l, r| l.sibling_of?(r) }.all?


### PR DESCRIPTION
This is a breaking change.

Each tree is a unique tree, so the root node of a tree has no siblings.

Fixes #590
