### PR TITLE
Refactor options storage

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -214,12 +214,12 @@ module Ancestry
 
     # Rebuild depth cache if it got corrupted or if depth caching was just turned on
     def rebuild_depth_cache!
-      raise Ancestry::AncestryException.new(I18n.t("ancestry.cannot_rebuild_depth_cache")) unless respond_to? :depth_cache_column
+      raise Ancestry::AncestryException.new(I18n.t("ancestry.cannot_rebuild_depth_cache")) unless ancestry_options[:cache_depth]
 
       self.ancestry_base_class.transaction do
         unscoped_where do |scope|
           scope.find_each do |node|
-            node.update_attribute depth_cache_column, node.depth
+            node.update_attribute ancestry_options[:depth_cache_column], node.depth
           end
         end
       end

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -125,7 +125,7 @@ module Ancestry
             if !node.sane_ancestor_ids?
               raise Ancestry::AncestryIntegrityException.new(I18n.t("ancestry.invalid_ancestry_column",
                                                                     :node_id => node.id,
-                                                                    :ancestry_column => "#{node.read_attribute node.ancestry_column}"
+                                                                    :ancestry_column => "#{node.read_attribute node.class.ancestry_column}"
                                                                     ))
             end
             # ... check that all ancestors exist

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -2,7 +2,7 @@ module Ancestry
   module ClassMethods
     # Fetch tree node if necessary
     def to_node object
-      if object.is_a?(self.ancestry_base_class)
+      if object.is_a?(ancestry_base_class)
         object
       else
         unscoped_where { |scope| scope.find(object.try(primary_key) || object) }
@@ -11,7 +11,7 @@ module Ancestry
 
     # Scope on relative depth options
     def scope_depth depth_options, depth
-      depth_options.inject(self.ancestry_base_class) do |scope, option|
+      depth_options.inject(ancestry_base_class) do |scope, option|
         scope_name, relative_depth = option
         if [:before_depth, :to_depth, :at_depth, :from_depth, :after_depth].include? scope_name
           scope.send scope_name, depth + relative_depth
@@ -29,9 +29,9 @@ module Ancestry
     # Get all nodes and sort them into an empty hash
     def arrange options = {}
       if (order = options.delete(:order))
-        arrange_nodes self.ancestry_base_class.order(order).where(options)
+        arrange_nodes ancestry_base_class.order(order).where(options)
       else
-        arrange_nodes self.ancestry_base_class.where(options)
+        arrange_nodes ancestry_base_class.where(options)
       end
     end
 
@@ -164,7 +164,7 @@ module Ancestry
     def restore_ancestry_integrity!
       parent_ids = {}
       # Wrap the whole thing in a transaction ...
-      self.ancestry_base_class.transaction do
+      ancestry_base_class.transaction do
         unscoped_where do |scope|
           # For each node ...
           scope.find_each do |node|
@@ -216,7 +216,7 @@ module Ancestry
     def rebuild_depth_cache!
       raise Ancestry::AncestryException.new(I18n.t("ancestry.cannot_rebuild_depth_cache")) unless ancestry_options[:cache_depth]
 
-      self.ancestry_base_class.transaction do
+      ancestry_base_class.transaction do
         unscoped_where do |scope|
           scope.find_each do |node|
             node.update_attribute ancestry_options[:depth_cache_column], node.depth
@@ -226,7 +226,7 @@ module Ancestry
     end
 
     def unscoped_where
-      yield self.ancestry_base_class.default_scoped.unscope(:where)
+      yield ancestry_base_class.default_scoped.unscope(:where)
     end
 
     ANCESTRY_UNCAST_TYPES = [:string, :uuid, :text].freeze

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -21,18 +21,18 @@ module Ancestry
       orphan_strategy = options[:orphan_strategy] || :destroy
 
       # Create ancestry column accessor and set to option or default
-      cattr_accessor :ancestry_column
-      self.ancestry_column = options[:ancestry_column] || :ancestry
+      self.class_variable_set('@@ancestry_column', options[:ancestry_column] || :ancestry)
+      cattr_reader :ancestry_column, instance_reader: false
 
       cattr_accessor :ancestry_primary_key_format
       self.ancestry_primary_key_format = options[:primary_key_format].presence || Ancestry.default_primary_key_format
 
-      cattr_accessor :ancestry_delimiter
-      self.ancestry_delimiter = '/'
+      self.class_variable_set('@@ancestry_delimiter', '/')
+      cattr_reader :ancestry_delimiter, instance_reader: false
 
       # Save self as base class (for STI)
-      cattr_accessor :ancestry_base_class
-      self.ancestry_base_class = self
+      self.class_variable_set('@@ancestry_base_class', self)
+      cattr_reader :ancestry_base_class
 
       # Touch ancestors after updating
       cattr_accessor :touch_ancestors

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -42,7 +42,7 @@ module Ancestry
 
       # Save self as base class (for STI)
       self.class_variable_set('@@ancestry_base_class', self)
-      cattr_reader :ancestry_base_class
+      cattr_reader :ancestry_base_class, instance_reader: false
 
       # Include instance methods
       include Ancestry::InstanceMethods

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -74,7 +74,7 @@ module Ancestry
 
     # Counter Cache
     def increase_parent_counter_cache
-      self.ancestry_base_class.increment_counter self.class.ancestry_options[:counter_cache_column], parent_id
+      self.class.ancestry_base_class.increment_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def decrease_parent_counter_cache
@@ -86,14 +86,14 @@ module Ancestry
       return if defined?(@_trigger_destroy_callback) && !@_trigger_destroy_callback
       return if ancestry_callbacks_disabled?
 
-      self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id
+      self.class.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def update_parent_counter_cache
       return unless saved_change_to_attribute?(self.class.ancestry_column)
 
       if parent_id_was = parent_id_before_last_save
-        self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id_was
+        self.class.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id_was
       end
 
       parent_id && increase_parent_counter_cache
@@ -132,7 +132,7 @@ module Ancestry
 
     def ancestors depth_options = {}
       return self.class.none unless has_parent?
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
+      self.class.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
     end
 
     def path_ids
@@ -144,7 +144,7 @@ module Ancestry
     end
 
     def path depth_options = {}
-      self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
+      self.class.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
     end
 
     def depth
@@ -214,7 +214,7 @@ module Ancestry
     # Children
 
     def children
-      self.ancestry_base_class.children_of(self)
+      self.class.ancestry_base_class.children_of(self)
     end
 
     def child_ids
@@ -238,7 +238,7 @@ module Ancestry
     # Siblings
 
     def siblings
-      self.ancestry_base_class.siblings_of(self)
+      self.class.ancestry_base_class.siblings_of(self)
     end
 
     # NOTE: includes self
@@ -263,7 +263,7 @@ module Ancestry
     # Descendants
 
     def descendants depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).descendants_of(self)
     end
 
     def descendant_ids depth_options = {}
@@ -277,7 +277,7 @@ module Ancestry
     # Indirects
 
     def indirects depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).indirects_of(self)
     end
 
     def indirect_ids depth_options = {}
@@ -291,7 +291,7 @@ module Ancestry
     # Subtree
 
     def subtree depth_options = {}
-      self.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
+      self.class.ancestry_base_class.ordered_by_ancestry.scope_depth(depth_options, depth).subtree_of(self)
     end
 
     def subtree_ids depth_options = {}
@@ -314,13 +314,13 @@ module Ancestry
   private
     def unscoped_descendants
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_conditions(self)
+        scope.where self.class.ancestry_base_class.descendant_conditions(self)
       end
     end
 
     def unscoped_descendants_before_save
       unscoped_where do |scope|
-        scope.where self.ancestry_base_class.descendant_before_save_conditions(self)
+        scope.where self.class.ancestry_base_class.descendant_before_save_conditions(self)
       end
     end
 
@@ -338,7 +338,7 @@ module Ancestry
     end
 
     def unscoped_where
-      self.ancestry_base_class.unscoped_where do |scope|
+      self.class.ancestry_base_class.unscoped_where do |scope|
         yield scope
       end
     end

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -90,9 +90,7 @@ module Ancestry
     end
 
     def update_parent_counter_cache
-      changed = saved_change_to_attribute?(self.ancestry_base_class.ancestry_column)
-
-      return unless changed
+      return unless saved_change_to_attribute?(self.class.ancestry_column)
 
       if parent_id_was = parent_id_before_last_save
         self.ancestry_base_class.decrement_counter counter_cache_column, parent_id_was
@@ -109,7 +107,7 @@ module Ancestry
     alias :ancestors? :has_parent?
 
     def ancestry_changed?
-      column = self.ancestry_base_class.ancestry_column.to_s
+      column = self.class.ancestry_column.to_s
         # These methods return nil if there are no changes.
         # This was fixed in a refactoring in rails 6.0: https://github.com/rails/rails/pull/35933
         !!(will_save_change_to_attribute?(column) || saved_change_to_attribute?(column))
@@ -119,7 +117,7 @@ module Ancestry
       current_context, self.validation_context = validation_context, nil
       errors.clear
 
-      attribute = ancestry_base_class.ancestry_column
+      attribute = self.class.ancestry_column
       ancestry_value = send(attribute)
       return true unless ancestry_value
 
@@ -220,7 +218,7 @@ module Ancestry
     end
 
     def child_ids
-      children.pluck(self.ancestry_base_class.primary_key)
+      children.pluck(self.class.primary_key)
     end
 
     def has_children?
@@ -245,7 +243,7 @@ module Ancestry
 
     # NOTE: includes self
     def sibling_ids
-      siblings.pluck(self.ancestry_base_class.primary_key)
+      siblings.pluck(self.class.primary_key)
     end
 
     def has_siblings?
@@ -269,7 +267,7 @@ module Ancestry
     end
 
     def descendant_ids depth_options = {}
-      descendants(depth_options).pluck(self.ancestry_base_class.primary_key)
+      descendants(depth_options).pluck(self.class.primary_key)
     end
 
     def descendant_of?(node)
@@ -283,7 +281,7 @@ module Ancestry
     end
 
     def indirect_ids depth_options = {}
-      indirects(depth_options).pluck(self.ancestry_base_class.primary_key)
+      indirects(depth_options).pluck(self.class.primary_key)
     end
 
     def indirect_of?(node)
@@ -297,7 +295,7 @@ module Ancestry
     end
 
     def subtree_ids depth_options = {}
-      subtree(depth_options).pluck(self.ancestry_base_class.primary_key)
+      subtree(depth_options).pluck(self.class.primary_key)
     end
 
     # Callback disabling

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -62,7 +62,7 @@ module Ancestry
 
     # Touch each of this record's ancestors (after save)
     def touch_ancestors_callback
-      return unless !ancestry_callbacks_disabled? && ancestry_base_class.ancestry_options[:touch]
+      return unless !ancestry_callbacks_disabled? && self.class.ancestry_options[:touch]
 
       # Touch each of the old *and* new ancestors
       unscoped_current_and_previous_ancestors.each do |ancestor|
@@ -74,7 +74,7 @@ module Ancestry
 
     # Counter Cache
     def increase_parent_counter_cache
-      self.ancestry_base_class.increment_counter ancestry_base_class.ancestry_options[:counter_cache_column], parent_id
+      self.ancestry_base_class.increment_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def decrease_parent_counter_cache
@@ -86,14 +86,14 @@ module Ancestry
       return if defined?(@_trigger_destroy_callback) && !@_trigger_destroy_callback
       return if ancestry_callbacks_disabled?
 
-      self.ancestry_base_class.decrement_counter ancestry_base_class.ancestry_options[:counter_cache_column], parent_id
+      self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id
     end
 
     def update_parent_counter_cache
       return unless saved_change_to_attribute?(self.class.ancestry_column)
 
       if parent_id_was = parent_id_before_last_save
-        self.ancestry_base_class.decrement_counter ancestry_base_class.ancestry_options[:counter_cache_column], parent_id_was
+        self.ancestry_base_class.decrement_counter self.class.ancestry_options[:counter_cache_column], parent_id_was
       end
 
       parent_id && increase_parent_counter_cache
@@ -152,7 +152,7 @@ module Ancestry
     end
 
     def cache_depth
-      write_attribute ancestry_base_class.ancestry_options[:depth_cache_column], depth
+      write_attribute self.class.ancestry_options[:depth_cache_column], depth
     end
 
     def ancestor_of?(node)

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -131,7 +131,7 @@ module Ancestry
     end
 
     def ancestors depth_options = {}
-      return self.ancestry_base_class.none unless has_parent?
+      return self.class.none unless has_parent?
       self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.ancestors_of(self)
     end
 

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -106,7 +106,7 @@ module Ancestry
     end
 
     def ancestry_format_regexp
-      /\A#{ancestry_primary_key_format}(#{Regexp.escape(ancestry_delimiter)}#{ancestry_primary_key_format})*\z/.freeze
+      /\A#{ancestry_options[:primary_key_format]}(#{Regexp.escape(ancestry_delimiter)}#{ancestry_options[:primary_key_format]})*\z/.freeze
     end
 
     module InstanceMethods

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -112,29 +112,29 @@ module Ancestry
     module InstanceMethods
       # optimization - better to go directly to column and avoid parsing
       def ancestors?
-        read_attribute(self.ancestry_base_class.ancestry_column) != self.ancestry_base_class.ancestry_root
+        read_attribute(self.class.ancestry_column) != self.class.ancestry_root
       end
       alias :has_parent? :ancestors?
 
       def ancestor_ids=(value)
-        write_attribute(self.ancestry_base_class.ancestry_column, generate_ancestry(value))
+        write_attribute(self.class.ancestry_column, generate_ancestry(value))
       end
 
       def ancestor_ids
-        parse_ancestry_column(read_attribute(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(read_attribute(self.class.ancestry_column))
       end
 
       def ancestor_ids_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column))
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
       end
 
       def parent_id_before_last_save
-        parse_ancestry_column(attribute_before_last_save(self.ancestry_base_class.ancestry_column)).last
+        parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column)).last
       end
 
       # optimization - better to go directly to column and avoid parsing
       def sibling_of?(node)
-        self.read_attribute(self.ancestry_base_class.ancestry_column) == node.read_attribute(self.ancestry_base_class.ancestry_column)
+        self.read_attribute(self.class.ancestry_column) == node.read_attribute(node.class.ancestry_column)
       end
 
       # private (public so class methods can find it)
@@ -143,26 +143,26 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_in_database(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_in_database(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        [attribute_before_last_save(self.ancestry_base_class.ancestry_column), id].compact.join(self.ancestry_base_class.ancestry_delimiter)
+        [attribute_before_last_save(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
       end
 
       def parse_ancestry_column(obj)
-        return [] if obj.nil? || obj == self.ancestry_base_class.ancestry_root
-        obj_ids = obj.split(self.ancestry_base_class.ancestry_delimiter).delete_if(&:blank?)
+        return [] if obj.nil? || obj == self.class.ancestry_root
+        obj_ids = obj.split(self.class.ancestry_delimiter).delete_if(&:blank?)
         self.class.primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)
+          ancestor_ids.join(self.class.ancestry_delimiter)
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -35,7 +35,7 @@ module Ancestry
     end
 
     def ancestry_format_regexp
-      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_primary_key_format}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
+      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_options[:primary_key_format]}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
     end
 
     module InstanceMethods

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -42,20 +42,20 @@ module Ancestry
       def child_ancestry
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_in_database(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_in_database(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def child_ancestry_before_save
         # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
-        "#{attribute_before_last_save(self.ancestry_base_class.ancestry_column)}#{id}#{self.ancestry_base_class.ancestry_delimiter}"
+        "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
       def generate_ancestry(ancestor_ids)
         if ancestor_ids.present? && ancestor_ids.any?
-          "#{self.ancestry_base_class.ancestry_delimiter}#{ancestor_ids.join(self.ancestry_base_class.ancestry_delimiter)}#{self.ancestry_base_class.ancestry_delimiter}"
+          "#{self.class.ancestry_delimiter}#{ancestor_ids.join(self.class.ancestry_delimiter)}#{self.class.ancestry_delimiter}"
         else
-          self.ancestry_base_class.ancestry_root
+          self.class.ancestry_root
         end
       end
     end

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -4,11 +4,10 @@ module Ancestry
     def update_descendants_with_new_ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
-        ancestry_column = ancestry_base_class.ancestry_column
         old_ancestry = generate_ancestry( path_ids_before_last_save )
         new_ancestry = generate_ancestry( path_ids )
         update_clause = [
-          "#{ancestry_column} = regexp_replace(#{ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
+          "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
         if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -10,8 +10,8 @@ module Ancestry
           "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
-        if ancestry_base_class.ancestry_options[:cache_depth] && respond_to?(ancestry_base_class.ancestry_options[:depth_cache_column])
-          update_clause << "#{ancestry_base_class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
+        if self.class.ancestry_options[:cache_depth] && respond_to?(self.class.ancestry_options[:depth_cache_column])
+          update_clause << "#{self.class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{self.class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -10,9 +10,8 @@ module Ancestry
           "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]
 
-        if ancestry_base_class.respond_to?(:depth_cache_column) && respond_to?(ancestry_base_class.depth_cache_column)
-          depth_cache_column = ancestry_base_class.depth_cache_column.to_s
-          update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
+        if ancestry_base_class.ancestry_options[:cache_depth] && respond_to?(ancestry_base_class.ancestry_options[:depth_cache_column])
+          update_clause << "#{ancestry_base_class.ancestry_options[:depth_cache_column]} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{ancestry_base_class.ancestry_delimiter}]', '', 'g')) #{ancestry_base_class.ancestry_options[:ancestry_format] == :materialized_path2 ? '-' : '+'} 1"
         end
 
         unscoped_descendants_before_save.update_all update_clause.join(', ')

--- a/test/concerns/has_ancestry_test.rb
+++ b/test/concerns/has_ancestry_test.rb
@@ -13,15 +13,6 @@ class HasAncestryTreeTest < ActiveSupport::TestCase
     end
   end
 
-  def test_setting_ancestry_column
-    AncestryTestDatabase.with_model do |model|
-      model.ancestry_column = :ancestors
-      assert_equal :ancestors, model.ancestry_column
-      model.ancestry_column = :ancestry
-      assert_equal :ancestry, model.ancestry_column
-    end
-  end
-
   def test_invalid_has_ancestry_options
     assert_raise Ancestry::AncestryException do
       Class.new(ActiveRecord::Base).has_ancestry :this_option_doesnt_exist => 42


### PR DESCRIPTION
This is #600 rebased and with commits split up/flattened.

- All writers are removed. (you shouldn't change ancestry options on-the-fly, that'll lead to unexpected behavior)
- All instance accessors are removed.
- Even though we do not mention `ancestry_column` or `ancestry_delimiter` accessors in the docs, this will be a breaking change for developers, so lets bump a major version.

@kshnurov Please let me know if you feel this does not accurately reflect your previous PR
I was having trouble splitting apart your commits and still giving you attribution