### PR TITLE
Support overriding apply_orphan_strategy

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -68,12 +68,18 @@ module Ancestry
 
       # Apply orphan strategy before destroy
       case orphan_strategy
-      when :rootify  then before_destroy :apply_orphan_strategy_rootify
-      when :destroy  then before_destroy :apply_orphan_strategy_destroy
-      when :adopt    then before_destroy :apply_orphan_strategy_adopt
-      when :restrict then before_destroy :apply_orphan_strategy_restrict
-      else raise Ancestry::AncestryException.new(I18n.t("ancestry.invalid_orphan_strategy"))
+      when :rootify
+        alias_method :apply_orphan_strategy, :apply_orphan_strategy_rootify
+      when :destroy
+        alias_method :apply_orphan_strategy, :apply_orphan_strategy_destroy
+      when :adopt
+        alias_method :apply_orphan_strategy, :apply_orphan_strategy_adopt
+      when :restrict
+        alias_method :apply_orphan_strategy, :apply_orphan_strategy_restrict
+      else
+        raise Ancestry::AncestryException.new(I18n.t("ancestry.invalid_orphan_strategy"))
       end
+      before_destroy :apply_orphan_strategy
 
       # Create ancestry column accessor and set to option or default
       if options[:cache_depth]

--- a/test/concerns/orphan_strategies_test.rb
+++ b/test/concerns/orphan_strategies_test.rb
@@ -69,6 +69,23 @@ class OphanStrategiesTest < ActiveSupport::TestCase
     end
   end
 
+  def test_override_apply_orphan_strategy
+    AncestryTestDatabase.with_model orphan_strategy: :destroy do |model, roots|
+      root  = model.create!
+      child = model.create!(:parent => root)
+      model.class_eval do
+        def apply_orphan_strategy
+          # disabling destoy callback
+        end
+      end
+      assert_difference 'model.count', -1 do
+        root.destroy
+      end
+      # this should not throw an ActiveRecord::RecordNotFound exception
+      assert child.reload.root_id == root.id
+    end
+  end
+
   def test_basic_delete
     AncestryTestDatabase.with_model do |model|
       n1 = model.create!                  #create a root node


### PR DESCRIPTION
apply_orphan_strategy was removed in #617
Many gems override this method to apply a custom orphan strategy

This adds support back and adds a test around the behavior

breaking change:

If a developer calls `super()` from `apply_orphan_strategy`, it will no longer work.
Fix:
directly call the desired strategy `apply_orphan_strategy_*` instead
