### PR TITLE
Changes to update_descendants_with_new_ancestry

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -59,7 +59,7 @@ module Ancestry
       validate :ancestry_exclude_self
 
       # Update descendants with new ancestry after update
-      after_update :update_descendants_with_new_ancestry
+      after_update :update_descendants_with_new_ancestry, if: :ancestry_changed?
 
       # Apply orphan strategy before destroy
       case orphan_strategy

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -7,8 +7,9 @@ module Ancestry
 
     # Update descendants with new ancestry (after update)
     def update_descendants_with_new_ancestry
-      # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
-      if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
+      # If enabled and the new ancestry is sane ...
+      # The only way the ancestry could be bad is via `update_attribute` with a bad value
+      if !ancestry_callbacks_disabled? && sane_ancestor_ids?
         # ... for each descendant ...
         unscoped_descendants_before_save.each do |descendant|
           # ... replace old ancestry with new ancestry

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -3,7 +3,8 @@ module Ancestry
     # Update descendants with new ancestry (after update)
     def update_descendants_with_new_ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
-      if !ancestry_callbacks_disabled? && !new_record? && ancestry_changed? && sane_ancestor_ids?
+      # The only way the ancestry could be bad is via `update_attribute` with a bad value
+      if !ancestry_callbacks_disabled? && sane_ancestor_ids?
         old_ancestry = generate_ancestry( path_ids_before_last_save )
         new_ancestry = generate_ancestry( path_ids )
         update_clause = [

--- a/test/concerns/validations_test.rb
+++ b/test/concerns/validations_test.rb
@@ -3,17 +3,24 @@ require_relative '../environment'
 class ValidationsTest < ActiveSupport::TestCase
   def test_ancestry_column_validation
     AncestryTestDatabase.with_model do |model|
-      node = model.create
+      node = model.create # assuming id == 1
       if AncestryTestDatabase.materialized_path2?
-        vals = ['/3/', '/10/2/', '/1/4/30/', model.ancestry_root]
+        vals = ['/3/', '/10/2/', '/9/4/30/', model.ancestry_root]
       else
-        vals = ['3', '10/2', '1/4/30', model.ancestry_root]
+        vals = ['3', '10/2', '9/4/30', model.ancestry_root]
       end
       vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
-        node.valid?; assert node.errors[model.ancestry_column].blank?
+        assert node.sane_ancestor_ids?
+        node.valid?
+        assert node.errors[model.ancestry_column].blank?
       end
+    end
+  end
 
+  def test_ancestry_column_validation_fails
+    AncestryTestDatabase.with_model do |model|
+      node = model.create
       if AncestryTestDatabase.materialized_path2?
         vals = ['/a/', '/a/b/', '/-34/']
       else
@@ -21,12 +28,14 @@ class ValidationsTest < ActiveSupport::TestCase
       end
       vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
-        node.valid?; assert !node.errors[model.ancestry_column].blank?
+        refute node.sane_ancestor_ids?
+        node.valid?
+        refute node.errors[model.ancestry_column].blank?
       end
     end
   end
 
-  def test_ancestry_column_validation_alt
+  def test_ancestry_column_validation_string_key
     AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/) do |model|
       node = model.create(:id => 'z')
       if AncestryTestDatabase.materialized_path2?
@@ -36,9 +45,15 @@ class ValidationsTest < ActiveSupport::TestCase
       end
       vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
-        node.valid?; assert node.errors[model.ancestry_column].blank?
+        node.valid?
+        assert node.errors[model.ancestry_column].blank?
       end
+    end
+  end
 
+  def test_ancestry_column_validation_string_key_fails
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/) do |model|
+      node = model.create(:id => 'z')
       if AncestryTestDatabase.materialized_path2?
         vals = ['/1/', '/1/2/', '/a-b/c/']
       else
@@ -46,7 +61,8 @@ class ValidationsTest < ActiveSupport::TestCase
       end
       vals.each do |value|
         node.send :write_attribute, model.ancestry_column, value
-        node.valid?; assert !node.errors[model.ancestry_column].blank?
+        node.valid?
+        refute node.errors[model.ancestry_column].blank?
       end
     end
   end
@@ -56,7 +72,9 @@ class ValidationsTest < ActiveSupport::TestCase
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do
-        parent.update! :parent => child
+        parent.parent = child
+        refute parent.sane_ancestor_ids?
+        parent.save!
       end
     end
   end


### PR DESCRIPTION
- this is called after a save, no need to call `new_record?` (/via #589)
- moving `ancestry_changed?` in the callback definition
- had wanted to remove `sane_ancestor_ids?` since validations already ran
  Unfortunately, `update_attribute` (read: no validations) allows bogus ancestry through.

Decided to continue skipping updates if the ancestry is deemed not valid.
It can only get this way if a user intentionally skips validations.

Not sure the desired behavior if something is corrupting ancestor's ancestry value.
I can see reason why we may want to propagate these changes.
For now, keeping this skip updates check in place