### PR TITLE
Delete nodes from leafs up to root

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -36,7 +36,7 @@ module Ancestry
     def apply_orphan_strategy_destroy
       return if ancestry_callbacks_disabled? || new_record?
 
-      unscoped_descendants.each do |descendant|
+      unscoped_descendants.ordered_by_ancestry.reverse_order.each do |descendant|
         descendant.without_ancestry_callbacks do
           descendant.destroy
         end


### PR DESCRIPTION
When destroying dependents, start with the furthest down leafs and work your way up to the current node

https://github.com/stefankroes/ancestry/issues/90

@miguelgraz @brendon You still using ancestry? Do you remember if this is the solution you used?

This seems like a good change, but want some feedback in terms of what unintended side effects will be introduced.
Current destroy does not specify an order. The database will tend towards insert order, and that tends to be parent down to children.