### PR TITLE
Add back ancestor_ids_in_database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Doing our best at supporting [SemVer](http://semver.org/) with
 a nice looking [Changelog](http://keepachangelog.com).
 
+## Version [4.3.1] <sub><sup>2023-03-17</sub></sup>
+* Fix: added back fields that were removed in #589 [#637](https://github.com/stefankroes/ancestry/pull/637) (thx @znz)
+  - ancestor_ids_in_database
+  - ancestor_id_before_last_save
+  - parent_id_in_database
+  - parent_id_before_last_save
+
 ## Version [4.3.0] <sub><sup>2023-03-09</sub></sup>
 
 * Fix: materialized_path2 strategy [#597](https://github.com/stefankroes/ancestry/pull/597) (thx @kshnurov)

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -124,8 +124,16 @@ module Ancestry
         parse_ancestry_column(read_attribute(self.class.ancestry_column))
       end
 
+      def ancestor_ids_in_database
+        parse_ancestry_column(attribute_in_database(self.class.ancestry_column))
+      end
+
       def ancestor_ids_before_last_save
         parse_ancestry_column(attribute_before_last_save(self.class.ancestry_column))
+      end
+
+      def parent_id_in_database
+        parse_ancestry_column(attribute_in_database(self.class.ancestry_column)).last
       end
 
       def parent_id_before_last_save

--- a/lib/ancestry/version.rb
+++ b/lib/ancestry/version.rb
@@ -1,3 +1,3 @@
 module Ancestry
-  VERSION = '4.3.0'
+  VERSION = '4.3.1'
 end

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -100,6 +100,56 @@ class TreeNavigationTest < ActiveSupport::TestCase
     end
   end
 
+  def test_db_nodes
+    AncestryTestDatabase.with_model do |model|
+      root = model.create!
+      node = model.new
+
+      # new / not saved
+      assert_equal [], node.ancestor_ids_in_database
+      assert_equal [], node.ancestor_ids_before_last_save
+      assert_nil node.parent_id
+      assert_nil node.parent_id_in_database
+      assert_nil node.parent_id_before_last_save
+
+      # saved
+      node.save!
+      assert_equal [], node.ancestor_ids
+      assert_equal [], node.ancestor_ids_in_database
+      assert_equal [], node.ancestor_ids_before_last_save
+      assert_nil node.parent_id
+      assert_nil node.parent_id_in_database
+      assert_nil node.parent_id_before_last_save
+
+      # changed / not saved
+      node.ancestor_ids = [root.id]
+      assert_equal [root.id], node.ancestor_ids
+      assert_equal [], node.ancestor_ids_in_database
+      assert_equal [], node.ancestor_ids_before_last_save
+      assert_equal root.id, node.parent_id
+      assert_nil node.parent_id_in_database
+      assert_nil node.parent_id_before_last_save
+
+      # changed / saved
+      node.save!
+      assert_equal [root.id], node.ancestor_ids
+      assert_equal [root.id], node.ancestor_ids_in_database
+      assert_equal [], node.ancestor_ids_before_last_save # ?
+      assert_equal root.id, node.parent_id
+      assert_equal root.id, node.parent_id_in_database
+      assert_nil node.parent_id_before_last_save # ?
+
+      # reloaded
+      node = model.find(node.id)
+      assert_equal [root.id], node.ancestor_ids
+      assert_equal [root.id], node.ancestor_ids_in_database
+      assert_equal [], node.ancestor_ids_before_last_save # ?
+      assert_equal root.id, node.parent_id
+      assert_equal root.id, node.parent_id_in_database
+      assert_nil node.parent_id_before_last_save # ?
+    end
+  end
+
   private
 
   def assert_attribute(value, node, attribute_name, attrid = nil)


### PR DESCRIPTION
this was removed by #589

adding fields back.
added tests to exercise

Fixes #636