### PR TITLE
Add path_ids_in_database back

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -133,6 +133,10 @@ module Ancestry
       ancestor_ids_before_last_save + [id]
     end
 
+    def path_ids_in_database
+      ancestor_ids_in_database + [id]
+    end
+
     def path depth_options = {}
       self.ancestry_base_class.scope_depth(depth_options, depth).ordered_by_ancestry.inpath_of(self)
     end

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -14,7 +14,7 @@ class TreeNavigationTest < ActiveSupport::TestCase
     indirects:   {attribute_ids: :indirect_ids},
     siblings:    {attribute_ids: :sibling_ids,   exists: :siblings?},
     subtree:     {attribute_ids: :subtree_ids},
-    path:        {attribute_ids: :path_ids},
+    path:        {attribute_ids: :path_ids, db: true},
   }
   # NOTE: has_ancestors? is an alias for parent? / ancestors? but not tested
 

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -2,19 +2,21 @@ require_relative '../environment'
 
 # this is testing attribute getters
 class TreeNavigationTest < ActiveSupport::TestCase
-  # yes, this is hardcoded. but got old redefininig it over and over again
+  # up:     |parent  |root       |ancestors|
+  # down:   |children|descendants|indirects|
+  # across: |siblings|subtree    |path     |
   ATTRIBUTE_MATRIX = {
-    ancestors:   {attribute_ids: :ancestor_ids,   exists: :ancestors?},
-    children:    {attribute_ids: :child_ids,      exists: :children?},
+    root:        {attribute_id:  :root_id,       exists: :root?},
+    parent:      {attribute_id:  :parent_id,     exists: :parent?,    db: true},
+    ancestors:   {attribute_ids: :ancestor_ids,  exists: :ancestors?, db: true},
+    children:    {attribute_ids: :child_ids,     exists: :children?},
     descendants: {attribute_ids: :descendant_ids},
     indirects:   {attribute_ids: :indirect_ids},
-    siblings:    {attribute_ids: :sibling_ids,    exists: :siblings?},
+    siblings:    {attribute_ids: :sibling_ids,   exists: :siblings?},
     subtree:     {attribute_ids: :subtree_ids},
     path:        {attribute_ids: :path_ids},
-
-    root:        {attribute_id: :root_id,         exists: :root?},
-    parent:      {attribute_id: :parent_id,       exists: :parent?} #has_parent?, :ancestors?
   }
+  # NOTE: has_ancestors? is an alias for parent? / ancestors? but not tested
 
   # class level getters are in test/concerns/scopes_test.rb
   # depth tests are in test/concerns/depth_constraints_tests.rb
@@ -27,150 +29,210 @@ class TreeNavigationTest < ActiveSupport::TestCase
       node2  = model.create!
       node21 = model.create!(:parent => node2)
 
-      # up:     |parent  |root       |ancestors|
-      # down:   |children|descendants|indirects|
-      # across: |siblings|subtree    |path     |
-
       # root: node1
-      assert_attribute(nil, node1, :parent)
-      refute node1.has_parent?
-      assert_attribute(node1, node1, :root)
-      assert_attributes([], node1, :ancestors)
-      assert_attributes([node11, node12], node1, :children)
-      assert_attributes([node11, node111, node12], node1, :descendants)
-      assert_attributes([node111], node1, :indirects)
-      assert_attributes([node1, node2], node1, :siblings)
-      assert_attributes([node1, node11, node111, node12], node1, :subtree)
-      assert_attributes([node1], node1, :path)
+      assert_attribute  node1, :parent, nil
+      assert_attribute  node1, :root, node1
+      assert_attributes node1, :ancestors, []
+      assert_attributes node1, :children, [node11, node12]
+      assert_attributes node1, :descendants, [node11, node111, node12]
+      assert_attributes node1, :indirects, [node111]
+      assert_attributes node1, :siblings, [node1, node2]
+      assert_attributes node1, :subtree, [node1, node11, node111, node12]
+      assert_attributes node1, :path, [node1]
       assert_equal(0, node1.depth)
 
       # root: node11
-      assert_attribute(node1, node11, :parent)
-      assert node11.has_parent?
-      assert_attribute(node1, node11, :root)
-      assert_attributes([node1], node11, :ancestors)
-      assert_attributes([node111], node11, :children)
-      assert_attributes([node111], node11, :descendants)
-      assert_attributes([], node11, :indirects)
-      assert_attributes([node11, node12], node11, :siblings)
-      assert_attributes([node11, node111], node11, :subtree)
-      assert_attributes([node1, node11], node11, :path)
+      assert_attribute  node11, :parent, node1
+      assert_attribute  node11, :root, node1
+      assert_attributes node11, :ancestors, [node1]
+      assert_attributes node11, :children, [node111]
+      assert_attributes node11, :descendants, [node111]
+      assert_attributes node11, :indirects, []
+      assert_attributes node11, :siblings, [node11, node12]
+      assert_attributes node11, :subtree, [node11, node111]
+      assert_attributes node11, :path, [node1, node11]
       assert_equal(1, node11.depth)
 
       # root: node111
-      assert_attribute(node11, node111, :parent)
-      assert node111.has_parent?
-      assert_attribute(node1, node111, :root)
-      assert_attributes([node1, node11], node111, :ancestors)
-      assert_attributes([], node111, :children)
-      assert_attributes([], node111, :descendants)
-      assert_attributes([], node111, :indirects)
-      assert_attributes([node111], node111, :siblings, exists: false)
-      assert_attributes([node111], node111, :subtree)
-      assert_attributes([node1, node11, node111], node111, :path)
+      assert_attribute node111, :parent, node11
+      assert_attribute node111, :root, node1
+      assert_attributes node111, :ancestors, [node1, node11]
+      assert_attributes node111, :children, []
+      assert_attributes node111, :descendants, []
+      assert_attributes node111, :indirects, []
+      assert_attributes node111, :siblings, [node111], exists: false
+      assert_attributes node111, :subtree, [node111]
+      assert_attributes node111, :path, [node1, node11, node111]
       assert_equal(2, node111.depth)
 
       # root: node12
-      assert_attribute(node1, node12, :parent)
-      assert node12.has_parent?
-      assert_attribute(node1, node12, :root)
-      assert_attributes([node1], node12, :ancestors)
-      assert_attributes([], node12, :children)
-      assert_attributes([], node12, :descendants)
-      assert_attributes([], node12, :indirects)
-      assert_attributes([node11, node12], node12, :siblings)
-      assert_attributes([node12], node12, :subtree)
-      assert_attributes([node1, node12], node12, :path)
+      assert_attribute node12, :parent, node1
+      assert_attribute node12, :root, node1
+      assert_attributes node12, :ancestors, [node1]
+      assert_attributes node12, :children, []
+      assert_attributes node12, :descendants, []
+      assert_attributes node12, :indirects, []
+      assert_attributes node12, :siblings, [node11, node12]
+      assert_attributes node12, :subtree, [node12]
+      assert_attributes node12, :path, [node1, node12]
       assert_equal(1, node12.depth)
 
       # root: node2
-      assert_attribute(nil, node2, :parent)
-      refute node2.has_parent?
-      assert_attribute(node2, node2, :root)
-      assert_attributes([], node2, :ancestors)
-      assert_attributes([node21], node2, :children)
-      assert_attributes([node21], node2, :descendants)
-      assert_attributes([], node2, :indirects)
-      assert_attributes([node1, node2], node2, :siblings)
-      assert_attributes([node2, node21], node2, :subtree)
-      assert_attributes([node2], node2, :path)
+      assert_attribute node2, :parent, nil
+      assert_attribute node2, :root, node2
+      assert_attributes node2, :ancestors, []
+      assert_attributes node2, :children, [node21]
+      assert_attributes node2, :descendants, [node21]
+      assert_attributes node2, :indirects, []
+      assert_attributes node2, :siblings, [node1, node2]
+      assert_attributes node2, :subtree, [node2, node21]
+      assert_attributes node2, :path, [node2]
       assert_equal(0, node2.depth)
 
       # root: node21
-      assert_attribute(node2, node21, :parent)
-      assert node21.has_parent?
-      assert_attribute(node2, node21, :root)
-      assert_attributes([node2], node21, :ancestors)
-      assert_attributes([], node21, :children)
-      assert_attributes([], node21, :descendants)
-      assert_attributes([], node21, :indirects)
-      assert_attributes([node21], node21, :siblings, exists: false)
-      assert_attributes([node21], node21, :subtree)
-      assert_attributes([node2, node21], node21, :path)
+      assert_attribute node21, :parent, node2
+      assert_attribute node21, :root, node2
+      assert_attributes node21, :ancestors, [node2]
+      assert_attributes node21, :children, []
+      assert_attributes node21, :descendants, []
+      assert_attributes node21, :indirects, []
+      assert_attributes node21, :siblings, [node21], exists: false
+      assert_attributes node21, :subtree, [node21]
+      assert_attributes node21, :path, [node2, node21]
       assert_equal(1, node21.depth)
     end
   end
 
-  def test_db_nodes
+  def test_node_in_db_first_node
     AncestryTestDatabase.with_model do |model|
       root = model.create!
       node = model.new
 
       # new / not saved
-      assert_equal [], node.ancestor_ids_in_database
-      assert_equal [], node.ancestor_ids_before_last_save
-      assert_nil node.parent_id
-      assert_nil node.parent_id_in_database
-      assert_nil node.parent_id_before_last_save
+      assert_attributes node, :ancestors, []
+      # assert_attributes([nil], node, :path) # not valid yet
+      assert_attribute node, :parent, nil
 
       # saved
       node.save!
-      assert_equal [], node.ancestor_ids
-      assert_equal [], node.ancestor_ids_in_database
-      assert_equal [], node.ancestor_ids_before_last_save
-      assert_nil node.parent_id
-      assert_nil node.parent_id_in_database
-      assert_nil node.parent_id_before_last_save
+      assert_attributes node, :ancestors, []
+      assert_attributes node, :path, [node]
+      assert_attribute node, :parent, nil
 
       # changed / not saved
       node.ancestor_ids = [root.id]
-      assert_equal [root.id], node.ancestor_ids
-      assert_equal [], node.ancestor_ids_in_database
-      assert_equal [], node.ancestor_ids_before_last_save
-      assert_equal root.id, node.parent_id
-      assert_nil node.parent_id_in_database
-      assert_nil node.parent_id_before_last_save
+      assert_attributes node, :ancestors, [root], db: []
+      assert_attributes node, :path, [root, node], db: [node]
+      assert_attribute node, :parent, root, db: nil
 
       # changed / saved
       node.save!
-      assert_equal [root.id], node.ancestor_ids
-      assert_equal [root.id], node.ancestor_ids_in_database
-      assert_equal [], node.ancestor_ids_before_last_save # ?
-      assert_equal root.id, node.parent_id
-      assert_equal root.id, node.parent_id_in_database
-      assert_nil node.parent_id_before_last_save # ?
+      node = model.find(node.id)
+      assert_attributes node, :ancestors, [root]
+      assert_attributes node, :path, [root, node]
+      assert_attribute node, :parent, root
 
       # reloaded
       node = model.find(node.id)
-      assert_equal [root.id], node.ancestor_ids
-      assert_equal [root.id], node.ancestor_ids_in_database
-      assert_equal [], node.ancestor_ids_before_last_save # ?
-      assert_equal root.id, node.parent_id
-      assert_equal root.id, node.parent_id_in_database
-      assert_nil node.parent_id_before_last_save # ?
+      assert_attributes node, :ancestors, [root]
+      assert_attributes node, :path, [root, node]
+      assert_attribute node, :parent, root
+    end
+  end
+
+  # kinda same as last test, more concerned with children
+  def test_node_in_database_children
+    AncestryTestDatabase.with_model do |model|
+      node1   = model.create!
+      node11  = node1.children.create!
+      node111 = node11.children.create!
+      node2   = model.create!
+
+      # parent
+      assert_attributes node1, :ancestors, []
+      assert_attributes node1, :children, [node11]
+      assert_attributes node1, :descendants, [node11, node111]
+      assert_attributes node1, :indirects, [node111]
+
+      # non-parent
+      assert_attributes node2, :ancestors, []
+      assert_attributes node2, :children, []
+      assert_attributes node2, :descendants, []
+      assert_attributes node2, :indirects, []
+
+      # node
+      assert_attributes node11, :ancestors, [node1]
+      assert_attributes node11, :children, [node111]
+      assert_attributes node11, :descendants, [node111]
+
+      # changed (not saved)
+      node11.parent = node2
+      # reloads?
+
+      # old parent (not saved)
+      assert_attributes node1, :ancestors, []
+      assert_attributes node1, :children, [node11]
+      assert_attributes node1, :descendants, [node11, node111]
+      assert_attributes node1, :indirects, [node111]
+
+      # new parent (not saved)
+      assert_attributes node2, :ancestors, []
+      assert_attributes node2, :children, []
+      assert_attributes node2, :descendants, []
+      assert_attributes node2, :indirects, []
+
+      # node (not saved)
+      assert_attributes node11, :ancestors, [node2], db: [node1]
+      assert_attributes node11, :children, [node111]
+      assert_attributes node11, :descendants, [node111]
+
+      # in database (again - but in a different hierarchy)
+      node11.save!
+      node1.reload ; node2.reload
+      # are these necessary?
+      # do we want this to work without?
+
+      # old parent (saved)
+      assert_attributes node1, :ancestors, []
+      assert_attributes node1, :children, []
+      assert_attributes node1, :descendants, []
+      assert_attributes node1, :indirects, []
+
+      # new parent (saved)
+      assert_attributes node2, :ancestors, []
+      assert_attributes node2, :children, [node11]
+      assert_attributes node2, :descendants, [node11, node111]
+      assert_attributes node2, :indirects, [node111]
+
+      # node (saved)
+      assert_attributes node11, :ancestors, [node2]
+      assert_attributes node11, :children, [node111]
+      assert_attributes node11, :descendants, [node111]
+    end
+  end
     end
   end
 
   private
 
-  def assert_attribute(value, node, attribute_name)
-    attribute_id = "#{attribute_name}_id"
+  def assert_attribute(node, attribute_name, value, db: :value)
+    attribute_id = ATTRIBUTE_MATRIX[attribute_name][:attribute_id]
     if value.nil?
       assert_nil node.send(attribute_name)
       assert_nil node.send(attribute_id)
     else
-      assert_equal value,     node.send(attribute_name)
-      assert_equal value&.id, node.send(attribute_id)
+      assert_equal value,    node.send(attribute_name)
+      assert_equal value.id, node.send(attribute_id)
+    end
+
+    if ATTRIBUTE_MATRIX[attribute_name][:db]
+      attribute_db_name = "#{attribute_id}_in_database"
+      db = value if db == :value
+      if db.nil?
+        assert_nil node.send(attribute_db_name)
+      else
+        assert_equal db.id, node.send(attribute_db_name)
+      end
     end
   end
 
@@ -182,16 +244,24 @@ class TreeNavigationTest < ActiveSupport::TestCase
   # so attribute_name = false is passed in
   #
   # @param value [Array] expected output
-  # @param attribute_name [String|Symbol|false] attribute to test
-  # @param exists [true|false] (default values.present?) test the exists "attribute?
-  def assert_attributes(values, node, attribute_name, exists: nil)
+  # @param attribute_name [Symbol] attribute to test
+  # @param exists [true|false] test the exists "attribute? (default values.present?)
+  # @param db [Array[AR]]  value that should be reflected _in_database (default: use values) 
+  #                        skips if not supported in matrix
+  def assert_attributes(node, attribute_name, values, db: :values, exists: :values)
     attribute_ids = ATTRIBUTE_MATRIX[attribute_name][:attribute_ids]
     assert_equal values.map(&:id), node.send(attribute_name).order(:id).map(&:id)
     assert_equal values.map(&:id), node.send(attribute_ids).sort
 
+    if ATTRIBUTE_MATRIX[attribute_name][:db]
+      db = values if db == :values
+      attribute_db_name = "#{attribute_ids}_in_database"
+      assert_equal db.map(&:id), node.send(attribute_db_name).sort
+    end
+
     exists_name = ATTRIBUTE_MATRIX[attribute_name][:exists] or return
 
-    exists = values.present? if exists.nil?
+    exists = values.present? if exists == :values
     if exists
       assert node.send(exists_name)
     else

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -2,6 +2,20 @@ require_relative '../environment'
 
 # this is testing attribute getters
 class TreeNavigationTest < ActiveSupport::TestCase
+  # yes, this is hardcoded. but got old redefininig it over and over again
+  ATTRIBUTE_MATRIX = {
+    ancestors:   {attribute_ids: :ancestor_ids,   exists: :ancestors?},
+    children:    {attribute_ids: :child_ids,      exists: :children?},
+    descendants: {attribute_ids: :descendant_ids},
+    indirects:   {attribute_ids: :indirect_ids},
+    siblings:    {attribute_ids: :sibling_ids,    exists: :siblings?},
+    subtree:     {attribute_ids: :subtree_ids},
+    path:        {attribute_ids: :path_ids},
+
+    root:        {attribute_id: :root_id,         exists: :root?},
+    parent:      {attribute_id: :parent_id,       exists: :parent?} #has_parent?, :ancestors?
+  }
+
   # class level getters are in test/concerns/scopes_test.rb
   # depth tests are in test/concerns/depth_constraints_tests.rb
   def test_node_getters
@@ -21,81 +35,78 @@ class TreeNavigationTest < ActiveSupport::TestCase
       assert_attribute(nil, node1, :parent)
       refute node1.has_parent?
       assert_attribute(node1, node1, :root)
-      assert_attributes([], node1, :ancestors, :ancestor_ids)
-      assert_attributes([node11, node12], node1, :children, :child_ids)
-      assert_attributes([node11, node111, node12], node1, :descendants, :descendant_ids, false)
-      assert_attributes([node111], node1, :indirects, :indirect_ids, false)
-      assert_attributes([node1, node2], node1, :siblings, :sibling_ids)
-      assert_attributes([node1, node11, node111, node12], node1, :subtree, :subtree_ids, false)
-      assert_attributes([node1], node1, :path, nil, false)
+      assert_attributes([], node1, :ancestors)
+      assert_attributes([node11, node12], node1, :children)
+      assert_attributes([node11, node111, node12], node1, :descendants)
+      assert_attributes([node111], node1, :indirects)
+      assert_attributes([node1, node2], node1, :siblings)
+      assert_attributes([node1, node11, node111, node12], node1, :subtree)
+      assert_attributes([node1], node1, :path)
       assert_equal(0, node1.depth)
 
       # root: node11
       assert_attribute(node1, node11, :parent)
       assert node11.has_parent?
       assert_attribute(node1, node11, :root)
-      assert_attributes([node1], node11, :ancestors, :ancestor_ids)
-      assert_attributes([node111], node11, :children, :child_ids)
-      assert_attributes([node111], node11, :descendants, :descendant_ids, false)
-      assert_attributes([], node11, :indirects, :indirect_ids, false)
-      assert_attributes([node11, node12], node11, :siblings, :sibling_ids)
-      assert_attributes([node11, node111], node11, :subtree, :subtree_ids, false)
-      assert_attributes([node1, node11], node11, :path, nil, false)
+      assert_attributes([node1], node11, :ancestors)
+      assert_attributes([node111], node11, :children)
+      assert_attributes([node111], node11, :descendants)
+      assert_attributes([], node11, :indirects)
+      assert_attributes([node11, node12], node11, :siblings)
+      assert_attributes([node11, node111], node11, :subtree)
+      assert_attributes([node1, node11], node11, :path)
       assert_equal(1, node11.depth)
 
       # root: node111
       assert_attribute(node11, node111, :parent)
       assert node111.has_parent?
       assert_attribute(node1, node111, :root)
-      assert_attributes([node1, node11], node111, :ancestors, :ancestor_ids)
-      assert_attributes([], node111, :children, :child_ids)
-      assert_attributes([], node111, :descendants, :descendant_ids, false)
-      assert_attributes([], node111, :indirects, :indirect_ids, false)
-      assert_attributes([node111], node111, :siblings, :sibling_ids, false)
-      refute node111.siblings?
-      assert_attributes([node111], node111, :subtree, :subtree_ids, false)
-      assert_attributes([node1, node11, node111], node111, :path, nil, false)
+      assert_attributes([node1, node11], node111, :ancestors)
+      assert_attributes([], node111, :children)
+      assert_attributes([], node111, :descendants)
+      assert_attributes([], node111, :indirects)
+      assert_attributes([node111], node111, :siblings, exists: false)
+      assert_attributes([node111], node111, :subtree)
+      assert_attributes([node1, node11, node111], node111, :path)
       assert_equal(2, node111.depth)
 
       # root: node12
       assert_attribute(node1, node12, :parent)
       assert node12.has_parent?
       assert_attribute(node1, node12, :root)
-      assert_attributes([node1], node12, :ancestors, :ancestor_ids)
-      assert_attributes([], node12, :children, :child_ids)
-      assert_attributes([], node12, :descendants, :descendant_ids, false)
-      assert_attributes([], node12, :indirects, :indirect_ids, false)
-      assert_attributes([node11, node12], node12, :siblings, :sibling_ids, false)
-      refute node111.siblings?
-      assert_attributes([node12], node12, :subtree, :subtree_ids, false)
-      assert_attributes([node1, node12], node12, :path, nil, false)
+      assert_attributes([node1], node12, :ancestors)
+      assert_attributes([], node12, :children)
+      assert_attributes([], node12, :descendants)
+      assert_attributes([], node12, :indirects)
+      assert_attributes([node11, node12], node12, :siblings)
+      assert_attributes([node12], node12, :subtree)
+      assert_attributes([node1, node12], node12, :path)
       assert_equal(1, node12.depth)
 
       # root: node2
       assert_attribute(nil, node2, :parent)
       refute node2.has_parent?
       assert_attribute(node2, node2, :root)
-      assert_attributes([], node2, :ancestors, :ancestor_ids)
-      assert_attributes([node21], node2, :children, :child_ids)
-      assert_attributes([node21], node2, :descendants, :descendant_ids, false)
-      assert_attributes([], node2, :indirects, :indirect_ids, false)
-      assert_attributes([node1, node2], node2, :siblings, :sibling_ids)
-      assert_attributes([node2, node21], node2, :subtree, :subtree_ids, false)
-      assert_attributes([node2], node2, :path, nil, false)
+      assert_attributes([], node2, :ancestors)
+      assert_attributes([node21], node2, :children)
+      assert_attributes([node21], node2, :descendants)
+      assert_attributes([], node2, :indirects)
+      assert_attributes([node1, node2], node2, :siblings)
+      assert_attributes([node2, node21], node2, :subtree)
+      assert_attributes([node2], node2, :path)
       assert_equal(0, node2.depth)
 
       # root: node21
       assert_attribute(node2, node21, :parent)
       assert node21.has_parent?
       assert_attribute(node2, node21, :root)
-      assert_attributes([node2], node21, :ancestors, :ancestor_ids)
-      assert_attributes([], node21, :children, :child_ids)
-      assert_attributes([], node21, :descendants, :descendant_ids, false)
-      assert_attributes([], node21, :indirects, :indirect_ids, false)
-      assert_attributes([node21], node21, :siblings, :sibling_ids, false)
-      refute node111.siblings?
-      assert_attributes([node21], node21, :subtree, :subtree_ids, false)
-      assert_attributes([node2, node21], node21, :path, nil, false)
+      assert_attributes([node2], node21, :ancestors)
+      assert_attributes([], node21, :children)
+      assert_attributes([], node21, :descendants)
+      assert_attributes([], node21, :indirects)
+      assert_attributes([node21], node21, :siblings, exists: false)
+      assert_attributes([node21], node21, :subtree)
+      assert_attributes([node2, node21], node21, :path)
       assert_equal(1, node21.depth)
     end
   end
@@ -152,23 +163,39 @@ class TreeNavigationTest < ActiveSupport::TestCase
 
   private
 
-  def assert_attribute(value, node, attribute_name, attrid = nil)
+  def assert_attribute(value, node, attribute_name)
+    attribute_id = "#{attribute_name}_id"
     if value.nil?
       assert_nil node.send(attribute_name)
-      assert_nil node.send(attrid || "#{attribute_name}_id")
+      assert_nil node.send(attribute_id)
     else
       assert_equal value,     node.send(attribute_name)
-      assert_equal value&.id, node.send(attrid || "#{attribute_name}_id")
+      assert_equal value&.id, node.send(attribute_id)
     end
   end
 
-  def assert_attributes(values, node, attribute_name, attrid = nil, attrQ = nil)
+  # this is a short form for assert_eaual
+  # It tests the attribute, attribute_ids, and the attribute? method
+  # the singular vs plural form is not consistent and so attribute_ids is needed in many cases
+  #
+  # when testing db tests (attribute_in_database) only the attribute_ids is tested
+  # so attribute_name = false is passed in
+  #
+  # @param value [Array] expected output
+  # @param attribute_name [String|Symbol|false] attribute to test
+  # @param exists [true|false] (default values.present?) test the exists "attribute?
+  def assert_attributes(values, node, attribute_name, exists: nil)
+    attribute_ids = ATTRIBUTE_MATRIX[attribute_name][:attribute_ids]
     assert_equal values.map(&:id), node.send(attribute_name).order(:id).map(&:id)
-    assert_equal values.map(&:id), node.send(attrid || "#{attribute_name}_ids").sort
-    if values.empty? && attrQ != false
-      refute node.send(attrQ || "#{attribute_name}?")
-    elsif attrQ != false
-      assert node.send(attrQ || "#{attribute_name}?")
+    assert_equal values.map(&:id), node.send(attribute_ids).sort
+
+    exists_name = ATTRIBUTE_MATRIX[attribute_name][:exists] or return
+
+    exists = values.present? if exists.nil?
+    if exists
+      assert node.send(exists_name)
+    else
+      refute node.send(exists_name)
     end
   end
 end


### PR DESCRIPTION
added `path_ids_in_database` back.
It was removed by mistake in #589 

Fixes #645 