### PR TITLE
Drop touch and ancestry_primary_key_format

### DIFF
--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -30,6 +30,7 @@ module Ancestry
       cattr_reader :ancestry_base_class, instance_reader: false
 
       # Touch ancestors after updating
+      # days are limited. need to handle touch in pg case
       cattr_accessor :touch_ancestors
       self.touch_ancestors = options[:touch] || false
 
@@ -110,9 +111,11 @@ module Ancestry
         }
       end
 
-      after_touch :touch_ancestors_callback
-      after_destroy :touch_ancestors_callback
-      after_save :touch_ancestors_callback, if: :saved_changes?
+      if options[:touch]
+        after_touch :touch_ancestors_callback
+        after_destroy :touch_ancestors_callback
+        after_save :touch_ancestors_callback, if: :saved_changes?
+      end
     end
 
     def acts_as_tree(*args)

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -19,8 +19,7 @@ module Ancestry
       self.class_variable_set('@@ancestry_column', options[:ancestry_column] || :ancestry)
       cattr_reader :ancestry_column, instance_reader: false
 
-      cattr_accessor :ancestry_primary_key_format
-      self.ancestry_primary_key_format = options[:primary_key_format].presence || Ancestry.default_primary_key_format
+      primary_key_format = options[:primary_key_format].presence || Ancestry.default_primary_key_format
 
       self.class_variable_set('@@ancestry_delimiter', '/')
       cattr_reader :ancestry_delimiter, instance_reader: false
@@ -51,7 +50,7 @@ module Ancestry
 
       attribute self.ancestry_column, default: self.ancestry_root
 
-      validates self.ancestry_column, ancestry_validation_options
+      validates self.ancestry_column, ancestry_validation_options(primary_key_format)
 
       update_strategy = options[:update_strategy] || Ancestry.default_update_strategy
       include Ancestry::MaterializedPathPg if update_strategy == :sql

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -63,7 +63,7 @@ module Ancestry
 
     # Touch each of this record's ancestors (after save)
     def touch_ancestors_callback
-      if !ancestry_callbacks_disabled? && self.class.ancestry_base_class.touch_ancestors
+      if !ancestry_callbacks_disabled?
         # Touch each of the old *and* new ancestors
         unscoped_current_and_previous_ancestors.each do |ancestor|
           ancestor.without_ancestry_callbacks do

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -94,9 +94,9 @@ module Ancestry
 
     private
 
-    def ancestry_validation_options
+    def ancestry_validation_options(ancestry_primary_key_format)
       {
-        format: { with: ancestry_format_regexp },
+        format: { with: ancestry_format_regexp(ancestry_primary_key_format) },
         allow_nil: ancestry_nil_allowed?
       }
     end
@@ -105,8 +105,8 @@ module Ancestry
       true
     end
 
-    def ancestry_format_regexp
-      /\A#{ancestry_primary_key_format}(#{Regexp.escape(ancestry_delimiter)}#{ancestry_primary_key_format})*\z/.freeze
+    def ancestry_format_regexp(primary_key_format)
+      /\A#{primary_key_format}(#{Regexp.escape(ancestry_delimiter)}#{primary_key_format})*\z/.freeze
     end
 
     module InstanceMethods

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -34,8 +34,8 @@ module Ancestry
       false
     end
 
-    def ancestry_format_regexp
-      /\A#{Regexp.escape(ancestry_delimiter)}(#{ancestry_primary_key_format}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
+    def ancestry_format_regexp(primary_key_format)
+      /\A#{Regexp.escape(ancestry_delimiter)}(#{primary_key_format}#{Regexp.escape(ancestry_delimiter)})*\z/.freeze
     end
 
     module InstanceMethods


### PR DESCRIPTION
These parameters are passed into `has_ancestry` and consumed by it.

This is part of a trend to drop many of the exposed/class level configuration parameters in ancestry.

# touch

### Before

we referenced touch to determine if we should touch fields

### After

We do not install the callbacks unless we want the touch behavior.
Variable is now no longer needed.

# ancestry_primary_key_format

### Before

This was recently introduced in 3.4 and is a mechanism for passing the key format into the format class (e.g.: `materialized_path`) to determine the regular expression used for validation

### After

It is being passed into the format and no longer referenced via the class level variable. It no longer needs to be an exposed.
