### PR TITLE
Rename internal methods names to be more rails consistent

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -11,7 +11,7 @@ module Ancestry
       # The only way the ancestry could be bad is via `update_attribute` with a bad value
       if !ancestry_callbacks_disabled? && sane_ancestor_ids?
         # ... for each descendant ...
-        unscoped_descendants_before_save.each do |descendant|
+        unscoped_descendants_before_last_save.each do |descendant|
           # ... replace old ancestry with new ancestry
           descendant.without_ancestry_callbacks do
             new_ancestor_ids = path_ids + (descendant.ancestor_ids - path_ids_before_last_save)
@@ -316,16 +316,17 @@ module Ancestry
       defined?(@disable_ancestry_callbacks) && @disable_ancestry_callbacks
     end
 
-  private
+    private
+
     def unscoped_descendants
       unscoped_where do |scope|
         scope.where self.class.ancestry_base_class.descendant_conditions(self)
       end
     end
 
-    def unscoped_descendants_before_save
+    def unscoped_descendants_before_last_save
       unscoped_where do |scope|
-        scope.where self.class.ancestry_base_class.descendant_before_save_conditions(self)
+        scope.where self.class.ancestry_base_class.descendant_before_last_save_conditions(self)
       end
     end
 

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -39,15 +39,17 @@ module Ancestry
     end
 
     module InstanceMethods
+      # Please see notes for MaterializedPath#child_ancestry
       def child_ancestry
-        # New records cannot have children
         raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
         "#{attribute_in_database(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 
-      def child_ancestry_before_save
-        # New records cannot have children
-        raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record")) if new_record?
+      # Please see notes for MaterializedPath#child_ancestry_before_last_save
+      def child_ancestry_before_last_save
+        if new_record? || respond_to?(:previously_new_record?) && previously_new_record?
+          raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record"))
+        end
         "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
       end
 

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -16,7 +16,7 @@ module Ancestry
           update_clause << "#{depth_cache_column} = length(regexp_replace(regexp_replace(ancestry, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}'), '[^#{self.class.ancestry_delimiter}]', '', 'g')) #{self.class.ancestry_format == :materialized_path2 ? '-' : '+'} 1"
         end
 
-        unscoped_descendants_before_save.update_all update_clause.join(', ')
+        unscoped_descendants_before_last_save.update_all update_clause.join(', ')
       end
     end
   end

--- a/test/concerns/tree_navigation_test.rb
+++ b/test/concerns/tree_navigation_test.rb
@@ -243,8 +243,8 @@ class TreeNavigationTest < ActiveSupport::TestCase
           else
             raise "callback eabled for #{id}" if id != 2
             # want to make sure we're pointing at the correct nodes
-            actual = unscoped_descendants_before_save.order(:id).map(&:id)
-            raise "unscoped_descendants_before_save was #{actual}" unless actual == [3, 4, 5]
+            actual = unscoped_descendants_before_last_save.order(:id).map(&:id)
+            raise "unscoped_descendants_before_last_save was #{actual}" unless actual == [3, 4, 5]
             actual = path_ids_before_last_save
             raise "bad path_ids(before) is #{actual}" unless actual == [1, 2]
             actual = path_ids


### PR DESCRIPTION
Don't think these methods are used by extension developers.

- `unscoped_descendants_before_save`  => `unscoped_descendants_before_last_save`
- `descendant_before_save_conditions` => `descendant_before_last_save_conditions`
- `child_ancestry_before_save`        => `child_ancestry_before_last_save`

Did not rename `child_ancestry` => `child_ancestry_in_database`.
I went back and forth on this one.
I put in a note to hopefully help anyone confused by the code using `_in_database`.

Now throwing an error from `child_ancestry_before_last_save` for newly saved records. (rails >= 6.1)
This error is thrown if this scope is used from an `after_save` hook on a new record.
Either change the hook to an `after_update` or guard with a `previously_new_record?`.
Throwing an error because for new records, this value may point to `root` and bad things could happen.