### PR TITLE
Cache column option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ a nice looking [Changelog](http://keepachangelog.com).
 
 ## Version [HEAD] <sub><sup>Unreleased</sub></sup>
 
+* `build_cache_depth_sql!` is a single query. [#654](https://github.com/stefankroes/ancestry/pull/654)
 * Drop `ancestry_primary_key_format` [#649](https://github.com/stefankroes/ancestry/pull/649)
 * When destroying orphans, going from leafs up to node [#635](https://github.com/stefankroes/ancestry/pull/635) (thx @brendon)
 * Changed config setters to class readers [#633](https://github.com/stefankroes/ancestry/pull/633) (thx @kshurov)
@@ -12,20 +13,31 @@ a nice looking [Changelog](http://keepachangelog.com).
 
 #### Notable features
 
+Depth scopes now work without `cache_depth`. But please only use this in background
+jobs. if you need to do this in the ui, use the depth_caching.
+
+`build_cache_depth_sql!` is quicker than `build_cache_depth!` (1 query instead of N+1 queries).
+
+#### Deprecations
+
+- Option `:depth_cache_column` is going away.
+  Please use a single key instead: `cache_depth: :depth_cach_column_name`.
+  `cache_depth: true` still defaults to `ancestry_depth`.
 
 #### Breaking Changes
 
 * Options are no longer set via class methods. Using `has_ancestry` is now the only way to enable these features.
-  * These are readable class accessors but are possibly going away
+  These are all not part of the public API.
+  * These are now class level read only accessors
     - `ancestry_base_class`         (introduced 1.1, removed by #633)
     - `ancestry_column`             (introduced 1.2, removed by #633)
     - `ancestry_delimiter`          (introduced 4.3.0, removed by #633)
+    - `depth_cache_column`          (introduced 4.3.0, removed by #654)
   * These no longer have any accessors
-    - `ancestry_format`             (introduced 4.3.0, removed by TODO)
+    - `ancestry_format`             (introduced 4.3.0, removed by #654)
     - `orphan_strategy`             (introduced 1.1, removed by #617)
     - `ancestry_primary_key_format` (introduced 4.3.0, removed by #649)
     - `touch_ancestors`             (introduced 2.1, removed by TODO)
-    - `depth_cache_column`          (introduced 4.3.0, removed by TODO)
 * These are seen as internal and may go away:
   - `apply_orphan_strategy` (TODO: use `orphan_strategy => none` and define `before_destory`)
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,9 @@ The `has_ancestry` method supports the following options:
                            :adopt     The orphan subtree is added to the parent of the deleted node
                                       If the deleted node is Root, then rootify the orphan subtree
     :cache_depth           Cache the depth of each node (See Depth Cache section)
-                           false (default)
-
-    :depth_cache_column    column name to store depth cache
-                           'ancestry_depth' (default)
+                           false   Do not cache depth (default)
+                           true    Cache depth in 'ancestry_depth'
+                           String  Cache depth in column referenced
     :primary_key_format    regular expression that matches the format of the primary key
                            '[0-9]+'           (default) integer ids
                            '[-A-Fa-f0-9]{36}'           UUIDs

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -225,6 +225,10 @@ module Ancestry
       end
     end
 
+    def rebuild_depth_cache_sql!
+      update_all("#{depth_cache_column} = #{ancestry_depth_sql}")
+    end
+
     def unscoped_where
       yield ancestry_base_class.default_scoped.unscope(:where)
     end

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -9,8 +9,9 @@ module Ancestry
         end
       end
 
-      if options[:ancestry_format].present? && ![:materialized_path, :materialized_path2].include?( options[:ancestry_format] )
-        raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_format", value: options[:ancestry_format]))
+      ancestry_format = options[:ancestry_format] || Ancestry.default_ancestry_format
+      if ![:materialized_path, :materialized_path2].include?(ancestry_format)
+        raise Ancestry::AncestryException.new(I18n.t("ancestry.unknown_format", value: ancestry_format))
       end
 
       orphan_strategy = options[:orphan_strategy] || :destroy
@@ -38,9 +39,6 @@ module Ancestry
 
       # Include dynamic class methods
       extend Ancestry::ClassMethods
-
-      cattr_accessor :ancestry_format
-      self.ancestry_format = options[:ancestry_format] || Ancestry.default_ancestry_format
 
       if ancestry_format == :materialized_path2
         extend Ancestry::MaterializedPath2

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -80,7 +80,15 @@ module Ancestry
       if options[:cache_depth]
         # Create accessor for column name and set to option or default
         self.cattr_accessor :depth_cache_column
-        self.depth_cache_column = options[:depth_cache_column] || :ancestry_depth
+        self.depth_cache_column =
+          if options[:cache_depth] == true
+            options[:depth_cache_column]&.to_s || 'ancestry_depth'
+          else
+            options[:cache_depth].to_s
+          end
+        if options[:depth_cache_column]
+          ActiveSupport::Deprecation.warn("has_ancestry :depth_cache_column is deprecated. Use :cache_depth instead.")
+        end
 
         # Cache depth in depth cache column before save
         before_validation :cache_depth

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -103,7 +103,12 @@ module Ancestry
         scope :from_depth,   lambda { |depth| where("#{depth_cache_column} >= ?", depth) }
         scope :after_depth,  lambda { |depth| where("#{depth_cache_column} > ?", depth) }
       else
-        # TODO: pure sql implementation of these scopse around depth_sql (from strategy)
+        # this is not efficient, but it works
+        scope :before_depth, lambda { |depth| where("#{ancestry_depth_sql} < ?", depth) }
+        scope :to_depth,     lambda { |depth| where("#{ancestry_depth_sql} <= ?", depth) }
+        scope :at_depth,     lambda { |depth| where("#{ancestry_depth_sql} = ?", depth) }
+        scope :from_depth,   lambda { |depth| where("#{ancestry_depth_sql} >= ?", depth) }
+        scope :after_depth,  lambda { |depth| where("#{ancestry_depth_sql} > ?", depth) }
       end
 
       # Create counter cache column accessor and set to option or default

--- a/lib/ancestry/locales/en.yml
+++ b/lib/ancestry/locales/en.yml
@@ -10,7 +10,6 @@ en:
     option_must_be_hash: "Options for has_ancestry must be in a hash."
     unknown_option: "Unknown option for has_ancestry: %{key} => %{value}."
     unknown_format: "Unknown ancestry format: %{value}."
-    named_scope_depth_cache: "Named scope '%{scope_name}' is only available when depth caching is enabled."
 
     exclude_self: "%{class_name} cannot be a descendant of itself."
     cannot_delete_descendants: "Cannot delete record because it has descendants."

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -92,6 +92,15 @@ module Ancestry
       nil
     end
 
+    def ancestry_depth_sql
+      @ancestry_depth_sql ||=
+        begin
+          tmp = %{(LENGTH(#{table_name}.#{ancestry_column}) - LENGTH(REPLACE(#{table_name}.#{ancestry_column},'#{ancestry_delimiter}','')))}
+          tmp = tmp + "/#{ancestry_delimiter.size}" if ancestry_delimiter.size > 1
+          "(CASE WHEN #{table_name}.#{ancestry_column} IS NULL THEN 0 ELSE 1 + #{tmp} END)"
+        end
+    end
+
     private
 
     def ancestry_validation_options(ancestry_primary_key_format)

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -115,6 +115,10 @@ module Ancestry
       primary_key_is_an_integer? ? obj_ids.map!(&:to_i) : obj_ids
     end
 
+    def ancestry_depth_change(old_value, new_value)
+      parse_ancestry_column(new_value).size - parse_ancestry_column(old_value).size
+    end
+
     private
 
     def ancestry_validation_options(ancestry_primary_key_format)

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -37,6 +37,14 @@ module Ancestry
         end
     end
 
+    def generate_ancestry(ancestor_ids)
+      if ancestor_ids.present? && ancestor_ids.any?
+        "#{ancestry_delimiter}#{ancestor_ids.join(ancestry_delimiter)}#{ancestry_delimiter}"
+      else
+        ancestry_root
+      end
+    end
+
     private
 
     def ancestry_nil_allowed?
@@ -60,14 +68,6 @@ module Ancestry
           raise Ancestry::AncestryException.new(I18n.t("ancestry.no_child_for_new_record"))
         end
         "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
-      end
-
-      def generate_ancestry(ancestor_ids)
-        if ancestor_ids.present? && ancestor_ids.any?
-          "#{self.class.ancestry_delimiter}#{ancestor_ids.join(self.class.ancestry_delimiter)}#{self.class.ancestry_delimiter}"
-        else
-          self.class.ancestry_root
-        end
       end
     end
   end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -28,6 +28,15 @@ module Ancestry
       ancestry_delimiter
     end
 
+    def ancestry_depth_sql
+      @ancestry_depth_sql ||=
+        begin
+          tmp = %{(LENGTH(#{table_name}.#{ancestry_column}) - LENGTH(REPLACE(#{table_name}.#{ancestry_column},'#{ancestry_delimiter}','')))}
+          tmp = tmp + "/#{ancestry_delimiter.size}" if ancestry_delimiter.size > 1
+          "(#{tmp} -1)"
+        end
+    end
+
     private
 
     def ancestry_nil_allowed?

--- a/lib/ancestry/materialized_path_pg.rb
+++ b/lib/ancestry/materialized_path_pg.rb
@@ -5,8 +5,8 @@ module Ancestry
       # If enabled and node is existing and ancestry was updated and the new ancestry is sane ...
       # The only way the ancestry could be bad is via `update_attribute` with a bad value
       if !ancestry_callbacks_disabled? && sane_ancestor_ids?
-        old_ancestry = generate_ancestry( path_ids_before_last_save )
-        new_ancestry = generate_ancestry( path_ids )
+        old_ancestry = self.class.generate_ancestry( path_ids_before_last_save )
+        new_ancestry = self.class.generate_ancestry( path_ids )
         update_clause = [
           "#{self.class.ancestry_column} = regexp_replace(#{self.class.ancestry_column}, '^#{Regexp.escape(old_ancestry)}', '#{new_ancestry}')"
         ]

--- a/test/concerns/depth_caching_test.rb
+++ b/test/concerns/depth_caching_test.rb
@@ -38,21 +38,11 @@ class DepthCachingTest < ActiveSupport::TestCase
 
   def test_depth_scopes_unavailable
     AncestryTestDatabase.with_model do |model|
-      assert_raise Ancestry::AncestryException do
-        model.before_depth(1)
-      end
-      assert_raise Ancestry::AncestryException do
-        model.to_depth(1)
-      end
-      assert_raise Ancestry::AncestryException do
-        model.at_depth(1)
-      end
-      assert_raise Ancestry::AncestryException do
-        model.from_depth(1)
-      end
-      assert_raise Ancestry::AncestryException do
-        model.after_depth(1)
-      end
+      refute model.respond_to?(:before_depth)
+      refute model.respond_to?(:to_depth)
+      refute model.respond_to?(:at_depth)
+      refute model.respond_to?(:from_depth)
+      refute model.respond_to?(:after_depth)
     end
   end
 

--- a/test/concerns/depth_caching_test.rb
+++ b/test/concerns/depth_caching_test.rb
@@ -101,4 +101,22 @@ class DepthCachingTest < ActiveSupport::TestCase
       end
     end
   end
+
+  # we are already testing generate and parse against static values
+  # this assumes those are methods are tested and working
+  def test_ancestry_depth_change
+    AncestryTestDatabase.with_model do |model|
+      {
+        [[], [1]]        => +1,
+        [[1], []]        => -1,
+        [[1], [2]]       =>  0,
+        [[1], [1, 2, 3]] => +2,
+        [[1, 2, 3], [1]] => -2
+      }.each do |(before, after), diff|
+        a_before = model.generate_ancestry(before)
+        a_after = model.generate_ancestry(after)
+        assert_equal(diff, model.ancestry_depth_change(a_before, a_after))
+      end
+    end
+  end
 end

--- a/test/concerns/depth_caching_test.rb
+++ b/test/concerns/depth_caching_test.rb
@@ -2,7 +2,7 @@ require_relative '../environment'
 
 class DepthCachingTest < ActiveSupport::TestCase
   def test_depth_caching
-    AncestryTestDatabase.with_model :depth => 3, :width => 3, :cache_depth => true, :depth_cache_column => :depth_cache do |_model, roots|
+    AncestryTestDatabase.with_model :depth => 3, :width => 3, :cache_depth => :depth_cache do |_model, roots|
       roots.each do |lvl0_node, lvl0_children|
         assert_equal 0, lvl0_node.depth_cache
         lvl0_children.each do |lvl1_node, lvl1_children|
@@ -16,7 +16,7 @@ class DepthCachingTest < ActiveSupport::TestCase
   end
 
   def test_depth_caching_after_subtree_movement
-    AncestryTestDatabase.with_model :depth => 6, :width => 1, :cache_depth => true, :depth_cache_column => :depth_cache do |model, _roots|
+    AncestryTestDatabase.with_model :depth => 6, :width => 1, :cache_depth => :depth_cache do |model, _roots|
       node = model.at_depth(3).first
       node.update(:parent => model.roots.first)
       assert_equal(1, node.depth_cache)
@@ -57,7 +57,7 @@ class DepthCachingTest < ActiveSupport::TestCase
   end
 
   def test_rebuild_depth_cache
-    AncestryTestDatabase.with_model :depth => 3, :width => 3, :cache_depth => true, :depth_cache_column => :depth_cache do |model, _roots|
+    AncestryTestDatabase.with_model :depth => 3, :width => 3, :cache_depth => :depth_cache do |model, _roots|
       model.connection.execute("update test_nodes set depth_cache = null;")
 
       # Assert cache was emptied correctly

--- a/test/environment.rb
+++ b/test/environment.rb
@@ -121,7 +121,7 @@ class AncestryTestDatabase
 
     ActiveRecord::Base.connection.create_table 'test_nodes', **table_options do |table|
       table.send(column_type, ancestry_column, **column_options(force_allow_nil: skip_ancestry))
-      table.integer options[:depth_cache_column] || :ancestry_depth if options[:cache_depth]
+      table.integer options[:cache_depth] == true ? :ancestry_depth : options[:cache_depth] if options[:cache_depth]
       if options[:counter_cache]
         counter_cache_column = options[:counter_cache] == true ? :children_count : options[:counter_cache]
         table.integer counter_cache_column


### PR DESCRIPTION
- `build_depth_cache_sql!` is a faster version of `build_depth_cache`. Considering dropping the ruby version.
- dropped `ancestry_format`
- merged `cache_depth` and `depth_cache_column` options. Unsure which one we should use
- can use scopes without `depth_cache` (though you should only use that for background jobs because it will surely do a full table scan)