### PR TITLE
Extensible orphan_strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ a nice looking [Changelog](http://keepachangelog.com).
 
 ## Version [HEAD] <sub><sup>Unreleased</sub></sup>
 
+* Introduce `orphan_strategy: :none` [#658](https://github.com/stefankroes/ancestry/pull/658)
 * Introduce `rebuild_counter_cache!` to reset counter caches. [#663](https://github.com/stefankroes/ancestry/pull/663) [#668](https://github.com/stefankroes/ancestry/pull/668) (thx @RongRongTeng)
 * Documentation fixes [#664](https://github.com/stefankroes/ancestry/pull/664) [#667](https://github.com/stefankroes/ancestry/pull/667) (thx @motokikando, @onerinas)
 * Introduce `build_cache_depth_sql!`, a sql alternative to `build_cache_depth` [#654](https://github.com/stefankroes/ancestry/pull/654)
@@ -41,7 +42,7 @@ jobs. If you need to do this in the ui, please use `cache_depth`.
     - `ancestry_primary_key_format` (introduced 4.3.0, removed by #649)
     - `touch_ancestors`             (introduced 2.1, removed by TODO)
 * These are seen as internal and may go away:
-  - `apply_orphan_strategy` (TODO: use `orphan_strategy => none` and define `before_destory`)
+  - `apply_orphan_strategy` Please use `orphan_strategy: :none` and a custom `before_destory` instead.
 
 ## Version [4.3.3] <sub><sup>2023-04-01</sub></sup>
 

--- a/README.md
+++ b/README.md
@@ -164,33 +164,34 @@ The `has_ancestry` method supports the following options:
     :ancestry_column       Column name to store ancestry
                            'ancestry' (default)
     :ancestry_format       Format for ancestry column (see Ancestry Formats section):
-                           :materialized_path (default)     1/2/3, root nodes ancestry=nil
-                           :materialized_path2 (preferred) /1/2/3/, root nodes ancestry=/
-    :orphan_strategy       Instruct Ancestry what to do with children of a node that is destroyed:
+                           :materialized_path   1/2/3, root nodes ancestry=nil (default)
+                           :materialized_path2  /1/2/3/, root nodes ancestry=/ (preferred)
+    :orphan_strategy       How to handle children of a destroyed node:
                            :destroy   All children are destroyed as well (default)
                            :rootify   The children of the destroyed node become root nodes
                            :restrict  An AncestryException is raised if any children exist
                            :adopt     The orphan subtree is added to the parent of the deleted node
                                       If the deleted node is Root, then rootify the orphan subtree
-    :cache_depth           Cache the depth of each node (See Depth Cache section)
+    :cache_depth           Cache the depth of each node: (See Depth Cache section)
                            false   Do not cache depth (default)
                            true    Cache depth in 'ancestry_depth'
-                           String  Cache depth in column referenced
-    :primary_key_format    regular expression that matches the format of the primary key
-                           '[0-9]+'           (default) integer ids
-                           '[-A-Fa-f0-9]{36}'           UUIDs
-    :touch                 Instruct Ancestry to touch the ancestors of a node when it changes
-                           false (default) don't invalide nested key-based caches
-    :counter_cache         Whether to create counter cache column accessor.
-                           false (default) don't store a counter cache
-                           true            store counter cache in `children_count`.
-                           String          name of column to store counter cache.
-    :update_strategy       Choose the strategy to update descendants nodes
-                           :ruby (default) All descendants are updated using the ruby algorithm.
-                                           This triggers update callbacks for each descendant node
-                           :sql            All descendants are updated using a single SQL statement.
-                                           This strategy does not trigger update callbacks for the descendants.
-                                           This strategy is available only for PostgreSql implementations
+                           String  Cache depth in the column referenced
+    :primary_key_format    Regular expression that matches the format of the primary key:
+                           '[0-9]+'            integer ids (default)
+                           '[-A-Fa-f0-9]{36}'  UUIDs
+    :touch                 Touch the ancestors of a node when it changes:
+                           false  don't invalide nested key-based caches (default)
+                           true   touch all ancestors of previous and new parents
+    :counter_cache         Create counter cache column accessor:
+                           false  don't store a counter cache (default)
+                           true   store counter cache in `children_count`.
+                           String name of column to store counter cache.
+    :update_strategy       How to update descendants nodes:
+                           :ruby  All descendants are updated using the ruby algorithm. (default)
+                                  This triggers update callbacks for each descendant node
+                           :sql   All descendants are updated using a single SQL statement.
+                                  This strategy does not trigger update callbacks for the descendants.
+                                  This strategy is available only for PostgreSql implementations
 
 Legacy configuration using `acts_as_tree` is still available. Ancestry defers to `acts_as_tree` if that gem is installed.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The `has_ancestry` method supports the following options:
                            :restrict  An AncestryException is raised if any children exist
                            :adopt     The orphan subtree is added to the parent of the deleted node
                                       If the deleted node is Root, then rootify the orphan subtree
+                           :none      skip this logic. (add your own `before_destroy`)
     :cache_depth           Cache the depth of each node: (See Depth Cache section)
                            false   Do not cache depth (default)
                            true    Cache depth in 'ancestry_depth'


### PR DESCRIPTION
This introduces 2 ways for developers to extend the built in orphan strategies.

Fixes #142 

/cc @brendon Here is custom orphan strategies.

After implementing this, I'm thinking of keeping `:none` and dropping the custom string.

- `none` is straightforward and simple to document. The custom one is much harder (red flag)
- There is a gotcha requiring them to define it first. Requires a bunch of documentation (red flag)
- Defining your own `before_destroy` seems simple.
- Avoiding the build the callback gook would be nice. Maybe leaving this code as is but not documenting it may be a plan as well.
- I don't like people knowing about and overriding `apply_orphan_strategy`, but maybe it is not so bad.

As a developer, what is your take?

---


## Turning orphan strategy handling off

```ruby
class ModelBefore
  def apply_orphan_strategy # no longer necessary with :none
    # skip
  end
  has_ancestry orphan_strategy: :none
end

class ModelAfter
  has_ancestry orphan_strategy: :none
end
```

## Implementing a custom orphan strategy

```ruby
module CustomStrategy
  def apply_orphan_strategy_abc
    # custom goodness
  end
end

class ModelAfter1
  includes CustomStrategy
  has_ancestry orphan_strategy: :abc
end

class ModelAfter2
  includes CustomStrategy
  before_destroy :apply_orphan_strategy_abc
  has_ancestry orphan_strategy: :none
end
```