### PR TITLE
[4-3] Fixes `.sort_by_ancestry` with custom `ancestry_column`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Doing our best at supporting [SemVer](http://semver.org/) with
 a nice looking [Changelog](http://keepachangelog.com).
 
+## Version [4.3.3] <sub><sup>2023-04-01</sub></sup>
+
+* Fix: sort_by_ancesty with custom ancestry_column [#656](https://github.com/stefankroes/ancestry/pull/656) (thx @mitsuru)
+
 ## Version [4.3.2] <sub><sup>2023-03-25</sub></sup>
 
 * Fix: added back fields that were removed in #589 [#647](https://github.com/stefankroes/ancestry/pull/647) (thx @rastamhadi)

--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -109,7 +109,7 @@ module Ancestry
 
       unless arranged
         presorted_nodes = nodes.sort do |a, b|
-          rank = (a.ancestry || ' ') <=> (b.ancestry || ' ')
+          rank = (a.public_send(ancestry_column) || ' ') <=> (b.public_send(ancestry_column) || ' ')
           rank = yield(a, b) if rank == 0 && block_given?
           rank
         end

--- a/lib/ancestry/version.rb
+++ b/lib/ancestry/version.rb
@@ -1,3 +1,3 @@
 module Ancestry
-  VERSION = '4.3.2'
+  VERSION = '4.3.3'
 end

--- a/test/concerns/sort_by_ancestry_test.rb
+++ b/test/concerns/sort_by_ancestry_test.rb
@@ -233,4 +233,17 @@ class SortByAncestryTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_sort_by_ancestry_with_ancestry_column
+    AncestryTestDatabase.with_model :ancestry_column => :t1, :extra_columns => {:rank => :integer} do |model|
+      _, n2, n3, n4, n5, _ = build_ranked_tree(model)
+
+      records = model.sort_by_ancestry(model.all.ordered_by_ancestry_and(:rank).offset(1).take(4), &RANK_SORT)
+      if CORRECT
+        assert_equal [n3, n2, n4, n5].map(&:id), records.map(&:id)
+      else
+        assert_equal [n2, n4, n5, n3].map(&:id), records.map(&:id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
backporting #656 to 4.3

targeting 4.3.3