### PR TITLE
fix: `rebuild_counter_cache!` primary key cast problem

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -94,8 +94,8 @@ module Ancestry
 
     def child_ancestry_sql
       %{
-        CASE WHEN #{table_name}.#{ancestry_column} IS NULL THEN CAST(#{table_name}.#{primary_key} AS CHAR)
-        ELSE      #{concat("#{table_name}.#{ancestry_column}", "'#{ancestry_delimiter}'", "CAST(#{table_name}.#{primary_key} AS CHAR)")}
+        CASE WHEN #{table_name}.#{ancestry_column} IS NULL THEN CAST(#{table_name}.#{primary_key} AS VARCHAR)
+        ELSE      #{concat("#{table_name}.#{ancestry_column}", "'#{ancestry_delimiter}'", "CAST(#{table_name}.#{primary_key} AS VARCHAR)")}
         END
       }
     end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -29,7 +29,7 @@ module Ancestry
     end
 
     def child_ancestry_sql
-      concat("#{table_name}.#{ancestry_column}", "CAST(#{table_name}.#{primary_key} AS CHAR)", "'#{ancestry_delimiter}'")
+      concat("#{table_name}.#{ancestry_column}", "CAST(#{table_name}.#{primary_key} AS VARCHAR)", "'#{ancestry_delimiter}'")
     end
 
     def ancestry_depth_sql


### PR DESCRIPTION
Fix 
- https://github.com/stefankroes/ancestry/pull/663

Currently, when the primary key consists of more than one character and casts to `CHAR` without a specific length, it can lead to problems. This occurs because the default length for CHAR is 1, which may not be sufficient to accommodate the values of the primary key.

To resolve this issue, this PR changes casting the primary key column to `VARCHAR`.