### PR TITLE
fix uniqueness warning in mysql 6.0 tests

### DIFF
--- a/test/concerns/hooks_test.rb
+++ b/test/concerns/hooks_test.rb
@@ -39,7 +39,7 @@ class ArrangementTest < ActiveSupport::TestCase
       model.class_eval do
         before_save :update_name_path
         # this example will only work if the name field is unique across all levels
-        validates :name, :uniqueness => true
+        validates :name, :uniqueness => {case_sensitive: false}
 
         def update_name_path
           self.name_path = [parent&.name_path, name].compact.join('/')


### PR DESCRIPTION
This test on mysql rails 6.0 was throwing the following warning:

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1
```