### PR TITLE
add in_subtree_of? helper function, for symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The yellow nodes are those returned by the method.
 | includes self                 |self..indirects                                      |root..self                       |
 |`sibling_ids`                  |`subtree_ids`                                        |`path_ids`                       |
 |`has_siblings?`                |                                                     |                                 |
-|`sibling_of?(node)`            |                                                     |                                 |
+|`sibling_of?(node)`            |`in_subtree_of?`                                     |                                 |
 
 When using `STI` all classes are returned from the scopes unless you specify otherwise using `where(:type => "ChildClass")`.
 

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -303,6 +303,10 @@ module Ancestry
       subtree(depth_options).pluck(self.class.primary_key)
     end
 
+    def in_subtree_of?(node)
+      id == node.id || descendant_of?(node)
+    end
+
     # Callback disabling
 
     def without_ancestry_callbacks

--- a/test/concerns/tree_predicate_test.rb
+++ b/test/concerns/tree_predicate_test.rb
@@ -31,6 +31,10 @@ class TreePredicateTest < ActiveSupport::TestCase
         # Descendants assertions
         assert children.map { |n| !root.descendant_of?(n) }.all?
         assert children.map { |n| n.descendant_of?(root) }.all?
+        # Subtrees assertions
+        assert children.map { |n| n.in_subtree_of?(root) }.all?
+        assert children.map { |n| !root.in_subtree_of?(n) }.all?
+        assert root.in_subtree_of?(root)
       end
     end
   end


### PR DESCRIPTION
This adds an `in_subtree_of?` method, because I've written this code many times and figured it made sense upstream.