### PR TITLE
Optimize has_siblings? to use exists?

### DIFF
--- a/gemfiles/gemfile_71.gemfile
+++ b/gemfiles/gemfile_71.gemfile
@@ -7,6 +7,5 @@ gem "activerecord", "~> 7.1.3"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2.0"
-gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -255,7 +255,7 @@ module Ancestry
     end
 
     def has_siblings?
-      siblings.count > 1
+      siblings.where.not(self.class.primary_key => id).exists?
     end
     alias_method :siblings?, :has_siblings?
 


### PR DESCRIPTION
Greetings.
This PR optimizes the has_siblings? method to improve performance by using `exists?`
This aims to reduce unnecessary scan for sibling existence and improve the performance of sibling checks, especially when there are many records.

### Changes:
```SQL
# Before
SELECT COUNT(*) FROM "test_nodes" WHERE "test_nodes"."ancestry" IS X

# After
SELECT 1 AS one FROM "test_nodes" WHERE "test_nodes"."ancestry" IS X AND nodes"."id" != X
```