### PR TITLE
Specify the version of concurrent-ruby due to CI failure

### DIFF
--- a/gemfiles/gemfile_60.gemfile
+++ b/gemfiles/gemfile_60.gemfile
@@ -7,5 +7,6 @@ gem "activerecord", "~> 6.0.6"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "~> 1.6.9"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/gemfile_61.gemfile
+++ b/gemfiles/gemfile_61.gemfile
@@ -7,5 +7,6 @@ gem "activerecord", "~> 6.1.7"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "~> 1.6.9"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/gemfile_70.gemfile
+++ b/gemfiles/gemfile_70.gemfile
@@ -7,5 +7,6 @@ gem "activerecord", "~> 7.0.8"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/gemfile_71.gemfile
+++ b/gemfiles/gemfile_71.gemfile
@@ -7,5 +7,6 @@ gem "activerecord", "~> 7.1.3"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"


### PR DESCRIPTION
This pull request includes updates to several gemfiles to add a new dependency on `concurrent-ruby` with a version constraint. The changes ensure that the `concurrent-ruby` gem is included and compatible with the specified versions of ActiveSupport.

cf: https://github.com/stefankroes/ancestry/actions/runs/13213184051/job/37062101303?pr=693
`ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)`