### PR TITLE
Abstract all primary key references

### DIFF
--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -20,13 +20,13 @@ module Ancestry
     def ancestors_of(object)
       t = arel_table
       node = to_node(object)
-      where(t[primary_key].in(node.ancestor_ids))
+      where(t[ancestry_identifier_column].in(node.ancestor_ids))
     end
 
     def inpath_of(object)
       t = arel_table
       node = to_node(object)
-      where(t[primary_key].in(node.path_ids))
+      where(t[ancestry_identifier_column].in(node.path_ids))
     end
 
     def children_of(object)
@@ -64,7 +64,7 @@ module Ancestry
     def subtree_of(object)
       t = arel_table
       node = to_node(object)
-      descendants_of(node).or(where(t[primary_key].eq(node.id)))
+      descendants_of(node).or(where(t[ancestry_identifier_column].eq(node.ancestry_identifier_column)))
     end
 
     def siblings_of(object)
@@ -96,8 +96,8 @@ module Ancestry
 
     def child_ancestry_sql
       %{
-        CASE WHEN #{table_name}.#{ancestry_column} IS NULL THEN #{concat("#{table_name}.#{primary_key}")}
-        ELSE      #{concat("#{table_name}.#{ancestry_column}", "'#{ancestry_delimiter}'", "#{table_name}.#{primary_key}")}
+        CASE WHEN #{table_name}.#{ancestry_column} IS NULL THEN #{concat("#{table_name}.#{ancestry_identifier_column}")}
+        ELSE      #{concat("#{table_name}.#{ancestry_column}", "'#{ancestry_delimiter}'", "#{table_name}.#{ancestry_identifier_column}")}
         END
       }
     end
@@ -200,7 +200,7 @@ module Ancestry
       def child_ancestry
         raise(Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record")) if new_record?
 
-        [attribute_in_database(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
+        [attribute_in_database(self.class.ancestry_column), ancestry_identifier_column].compact.join(self.class.ancestry_delimiter)
       end
 
       # The ancestry value for this record's old children
@@ -212,7 +212,7 @@ module Ancestry
           raise Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record")
         end
 
-        [attribute_before_last_save(self.class.ancestry_column), id].compact.join(self.class.ancestry_delimiter)
+        [attribute_before_last_save(self.class.ancestry_column), ancestry_identifier_column].compact.join(self.class.ancestry_delimiter)
       end
     end
   end

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -31,7 +31,7 @@ module Ancestry
     end
 
     def child_ancestry_sql
-      concat("#{table_name}.#{ancestry_column}", "#{table_name}.#{primary_key}", "'#{ancestry_delimiter}'")
+      concat("#{table_name}.#{ancestry_column}", "#{table_name}.#{ancestry_identifier_column}", "'#{ancestry_delimiter}'")
     end
 
     def ancestry_depth_sql
@@ -68,7 +68,7 @@ module Ancestry
       def child_ancestry
         raise(Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record")) if new_record?
 
-        "#{attribute_in_database(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
+        "#{attribute_in_database(self.class.ancestry_column)}#{ancestry_identifier_column}#{self.class.ancestry_delimiter}"
       end
 
       # Please see notes for MaterializedPath#child_ancestry_before_last_save
@@ -77,7 +77,7 @@ module Ancestry
           raise(Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record"))
         end
 
-        "#{attribute_before_last_save(self.class.ancestry_column)}#{id}#{self.class.ancestry_delimiter}"
+        "#{attribute_before_last_save(self.class.ancestry_column)}#{ancestry_identifier_column}#{self.class.ancestry_delimiter}"
       end
     end
   end


### PR DESCRIPTION
Sample PR for #695 

（This pull request introduces a significant refactor to the `ancestry` library by replacing direct references to `primary_key` and `id` with a new method, `ancestry_identifier_column`）