### PR TITLE
Humanise model name for error message

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -4,7 +4,7 @@ module Ancestry
   module InstanceMethods
     # Validate that the ancestors don't include itself
     def ancestry_exclude_self
-      errors.add(:base, I18n.t("ancestry.exclude_self", class_name: self.class.name.humanize)) if ancestor_ids.include?(id)
+      errors.add(:base, I18n.t("ancestry.exclude_self", class_name: self.class.model_name.human)) if ancestor_ids.include?(id)
     end
 
     # Update descendants with new ancestry (after update)


### PR DESCRIPTION
Fixes #699 

The model name humanization was added in https://github.com/stefankroes/ancestry/pull/487 and the change was lost in internationalization attempt: https://github.com/stefankroes/ancestry/commit/f11cf9130a3b630e9d329fec2c33c8baf492c7d6. This PR adds it back.

> Imagine a model called ProductType. The old message was:
> `Producttype cannot be a descendant of itself.`
> The new message is:
> `Product type cannot be a descendant of itself.`