### PR TITLE
Move descendants conditions into instance builder methods

### DIFF
--- a/lib/ancestry/instance_methods.rb
+++ b/lib/ancestry/instance_methods.rb
@@ -82,18 +82,6 @@ module Ancestry
 
     private
 
-    def unscoped_descendants
-      unscoped_where do |scope|
-        scope.where(self.class.ancestry_base_class.descendant_conditions(self))
-      end
-    end
-
-    def unscoped_descendants_before_last_save
-      unscoped_where do |scope|
-        scope.where(self.class.ancestry_base_class.descendant_before_last_save_conditions(self))
-      end
-    end
-
     # works with after save context (hence before_last_save)
     def unscoped_current_and_previous_ancestors
       unscoped_where do |scope|

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -465,7 +465,7 @@ module Ancestry
         end
 
         def roots
-          where(arel_table[:#{column}].eq(#{root.inspect}))
+          where(#{format_module}.roots_condition(arel_table[:#{column}]))
         end
 
         def ancestors_of(object)
@@ -480,7 +480,7 @@ module Ancestry
 
         def children_of(object)
           node = to_node(object)
-          where(arel_table[:#{column}].eq(node.child_ancestry))
+          where(#{format_module}.children_condition(arel_table[:#{column}], node.child_ancestry))
         end
 
         def indirects_of(object)
@@ -500,11 +500,11 @@ module Ancestry
 
         def siblings_of(object)
           node = to_node(object)
-          where(arel_table[:#{column}].eq(node[#{column.inspect}]#{ ".presence" if root.nil? }))
+          where(#{format_module}.siblings_condition(arel_table[:#{column}], node[#{column.inspect}]))
         end
 
         def leaves
-          where("NOT EXISTS (SELECT 1 FROM \#{table_name} c WHERE c.#{column} = (\#{child_ancestry_sql}))")
+          where(#{format_module}.leaves_condition(arel_table[:#{column}], child_ancestry_sql))
         end
 
         def leaves_of(object)

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -479,21 +479,18 @@ module Ancestry
         end
 
         def descendants_of(object)
-          where(descendant_conditions(object))
-        end
-
-        def descendants_by_ancestry(child_ancestry)
-          #{format_module}.descendants_condition(arel_table[:#{column}], child_ancestry)
+          node = to_node(object)
+          where(#{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry))
         end
 
         def descendant_conditions(object)
           node = to_node(object)
-          descendants_by_ancestry(node.child_ancestry)
+          #{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry)
         end
 
         def descendant_before_last_save_conditions(object)
           node = to_node(object)
-          descendants_by_ancestry(node.child_ancestry_before_last_save)
+          #{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry_before_last_save)
         end
 
         def subtree_of(object)

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -438,6 +438,16 @@ module Ancestry
         def touch_ancestors_callback
           Ancestry::ClassMethods._touch_ancestors_callback(self)
         end
+
+        private
+
+        def unscoped_descendants
+          unscoped_where { |scope| scope.where(#{format_module}.descendants_condition(scope.arel_table[:#{column}], child_ancestry)) }
+        end
+
+        def unscoped_descendants_before_last_save
+          unscoped_where { |scope| scope.where(#{format_module}.descendants_condition(scope.arel_table[:#{column}], child_ancestry_before_last_save)) }
+        end
       RUBY
 
       # Class methods submodule — auto-extended when the main module is included
@@ -481,16 +491,6 @@ module Ancestry
         def descendants_of(object)
           node = to_node(object)
           where(#{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry))
-        end
-
-        def descendant_conditions(object)
-          node = to_node(object)
-          #{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry)
-        end
-
-        def descendant_before_last_save_conditions(object)
-          node = to_node(object)
-          #{format_module}.descendants_condition(arel_table[:#{column}], node.child_ancestry_before_last_save)
         end
 
         def subtree_of(object)

--- a/lib/ancestry/ltree.rb
+++ b/lib/ancestry/ltree.rb
@@ -39,6 +39,10 @@ module Ancestry
       ancestry_value.blank? ? id.to_s : "#{ancestry_value}.#{id}"
     end
 
+    def self.siblings_condition(attr, ancestry_value)
+      attr.eq(ancestry_value)
+    end
+
     # Arel condition: descendants using ltree <@ (descendant-of) operator
     def self.descendants_condition(attr, child_ancestry)
       Arel::Nodes::InfixOperation.new('<@', attr, Arel.sql("'#{child_ancestry}'"))

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -39,6 +39,29 @@ module Ancestry
       [ancestry_value, id].compact.join(DELIMITER)
     end
 
+    # Arel condition: root nodes have ancestry equal to the root value
+    def self.roots_condition(attr)
+      attr.eq(root)
+    end
+
+    # SQL condition: nodes with no children
+    # child_ancestry_sql: SQL expression that computes this node's child_ancestry
+    def self.leaves_condition(attr, child_ancestry_sql)
+      table_name = attr.relation.name
+      column_name = attr.name
+      "NOT EXISTS (SELECT 1 FROM #{table_name} c WHERE c.#{column_name} = (#{child_ancestry_sql}))"
+    end
+
+    # Arel condition: children have ancestry equal to child_ancestry
+    def self.children_condition(attr, child_ancestry)
+      attr.eq(child_ancestry)
+    end
+
+    # Arel condition: siblings share the same ancestry value
+    def self.siblings_condition(attr, ancestry_value)
+      attr.eq(ancestry_value.presence)
+    end
+
     # Arel condition: descendants have ancestry matching child_ancestry or starting with child_ancestry/
     def self.descendants_condition(attr, child_ancestry)
       attr.matches("#{child_ancestry}/%", nil, true).or(attr.eq(child_ancestry))

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -44,12 +44,11 @@ module Ancestry
       attr.eq(root)
     end
 
-    # SQL condition: nodes with no children
-    # child_ancestry_sql: SQL expression that computes this node's child_ancestry
+    # Arel condition: nodes with no children
     def self.leaves_condition(attr, child_ancestry_sql)
-      table_name = attr.relation.name
-      column_name = attr.name
-      "NOT EXISTS (SELECT 1 FROM #{table_name} c WHERE c.#{column_name} = (#{child_ancestry_sql}))"
+      child_table = Arel::Table.new(attr.relation.name, as: 'c')
+      subquery = child_table.where(child_table[attr.name].eq(Arel.sql(child_ancestry_sql))).project(1)
+      Arel::Nodes::Not.new(Arel::Nodes::Exists.new(subquery.ast))
     end
 
     # Arel condition: children have ancestry equal to child_ancestry

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -42,6 +42,10 @@ module Ancestry
       concat(adapter, "#{table_name}.#{ancestry_column}", "#{table_name}.#{primary_key}", "'/'")
     end
 
+    def self.siblings_condition(attr, ancestry_value)
+      attr.eq(ancestry_value)
+    end
+
     # mp2: descendants just use LIKE (trailing delimiter prevents false prefix matches)
     def self.descendants_condition(attr, child_ancestry)
       attr.matches("#{child_ancestry}%", nil, true)

--- a/lib/ancestry/materialized_path_array.rb
+++ b/lib/ancestry/materialized_path_array.rb
@@ -40,9 +40,9 @@ module Ancestry
     end
 
     def self.leaves_condition(attr, child_ancestry_sql)
-      table_name = attr.relation.name
-      column_name = attr.name
-      "NOT EXISTS (SELECT 1 FROM #{table_name} c WHERE c.#{column_name} = (#{child_ancestry_sql}))"
+      child_table = Arel::Table.new(attr.relation.name, as: 'c')
+      subquery = child_table.where(child_table[attr.name].eq(Arel.sql(child_ancestry_sql))).project(1)
+      Arel::Nodes::Not.new(Arel::Nodes::Exists.new(subquery.ast))
     end
 
     def self.children_condition(attr, child_ancestry)

--- a/lib/ancestry/materialized_path_array.rb
+++ b/lib/ancestry/materialized_path_array.rb
@@ -35,6 +35,24 @@ module Ancestry
       end
     end
 
+    def self.roots_condition(attr)
+      attr.eq(root)
+    end
+
+    def self.leaves_condition(attr, child_ancestry_sql)
+      table_name = attr.relation.name
+      column_name = attr.name
+      "NOT EXISTS (SELECT 1 FROM #{table_name} c WHERE c.#{column_name} = (#{child_ancestry_sql}))"
+    end
+
+    def self.children_condition(attr, child_ancestry)
+      attr.eq(child_ancestry)
+    end
+
+    def self.siblings_condition(attr, ancestry_value)
+      attr.eq(ancestry_value)
+    end
+
     # Arel condition: descendants have ancestry starting with child_ancestry prefix
     # Uses slice comparison (ancestry[1:N] = ARRAY[...]) for correct prefix matching.
     # @> containment is faster (GIN-indexable) but order-independent — it returns


### PR DESCRIPTION
## Description

Move SQL condition building from inline arel in the builder into format module methods. All ancestry column conditions now go through format modules, making them overridable per format and reusable from both class scopes and instance methods.

## Before

Condition logic was scattered:
- *_of scopes inline arel in the builder
- descendants_condition, indirects_condition in format modules
- leaves as raw SQL strings
- descendant_conditions and descendants_by_ancestry added indirection layers between callers and the format module.

## After

- Builder scopes call format module methods directly.
- unscoped_descendants moved from InstanceMethods to builder.

Format modules own all condition methods:

- roots_condition
- children_condition
- siblings_condition
- descendants_condition
- indirects_condition
- leaves_condition (now uses Arel)
