### PR TITLE
Memoize child_ancestry_sql on the model class

### DIFF
--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -520,7 +520,7 @@ module Ancestry
         end
 
         def child_ancestry_sql
-          #{format_module}.child_ancestry_sql(table_name, #{column.inspect}, :#{pk}, connection.adapter_name.downcase, integer_pk: #{integer_pk.inspect})
+          @child_ancestry_sql ||= #{format_module}.child_ancestry_sql(table_name, #{column.inspect}, :#{pk}, connection.adapter_name.downcase, integer_pk: #{integer_pk.inspect})
         end
 
         def ancestry_depth_sql


### PR DESCRIPTION
Before
======

- every call to child_ancestry_sql was a database call

After
======

- calls to child_ancestry_sql is cached in @child_ancestry_sql

Matches the existing ||= pattern used by ancestry_depth_sql,
ancestry_parent_id_sql, and ancestry_root_id_sql.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
