### PR TITLE
Reduce internal code to array-only concepts

### DIFF
--- a/lib/ancestry/class_methods.rb
+++ b/lib/ancestry/class_methods.rb
@@ -311,7 +311,7 @@ module Ancestry
     # Builder generates thin wrappers that delegate here with baked-in column.
 
     def self._ancestry_exclude_self(record)
-      record.errors.add(:base, I18n.t("ancestry.exclude_self", class_name: record.class.model_name.human)) if record.ancestor_ids.include?(record.id)
+      record.errors.add(:base, I18n.t("ancestry.exclude_self", class_name: record.class.model_name.human)) if record.ancestor_ids&.include?(record.id)
     end
 
     def self._update_descendants_with_new_ancestry(record)

--- a/lib/ancestry/has_ancestry.rb
+++ b/lib/ancestry/has_ancestry.rb
@@ -35,7 +35,6 @@ module Ancestry
       extend Ancestry::ClassMethods
 
       format_module = Ancestry::HasAncestry.ancestry_format_module(ancestry_format)
-      root = format_module.root
 
       # Resolve depth cache column name (or nil if virtual/absent)
       if options[:cache_depth] == :virtual
@@ -112,7 +111,7 @@ module Ancestry
       # Include generated module with baked-in column/format
       # This extends ClassMethods (scopes, helpers) and includes instance methods
       generated_mod = Ancestry::InstanceMethodsBuilder.build(
-        format_module, column, root,
+        format_module, column, format_module.root,
         integer_pk: integer_pk,
         depth_cache_column: depth_cache_column,
         counter_cache_column: counter_cache_column,

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -43,6 +43,24 @@ module Ancestry
         end
         alias has_parent? ancestors?
 
+        #{ if column.to_s == "ancestor_ids"
+        <<~RUBY
+          def ancestry
+            read_attribute(:#{column})&.join("/")
+          end
+
+          def ancestry=(value)
+            write_attribute(:#{column}, value&.split("/") || [])
+          end
+
+          def ancestor_ids=(value)
+            super
+            #{"ancestry_sync_parent_cache(#{parent_cache_column.inspect}, value)" if parent_cache_column || parent_association}
+            #{"ancestry_sync_root_cache(#{root_cache_column.inspect}, value)" if root_cache_column || root_association}
+          end
+        RUBY
+        else
+        <<~RUBY
         def ancestor_ids=(value)
           @_ancestor_ids = value.freeze
           write_attribute(:#{column}, #{format_module}.generate(value))
@@ -66,6 +84,8 @@ module Ancestry
         def ancestor_ids_before_last_save
           #{format_module}.#{parse_method}(attribute_before_last_save(:#{column}))
         end
+        RUBY
+        end}
 
         def parent_id_in_database
           ancestor_ids_in_database.last

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -38,9 +38,8 @@ module Ancestry
       Ancestry.const_set(mod_name, mod)
 
       mod.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-        # optimization - better to go directly to column and avoid parsing
         def ancestors?
-          read_attribute(:#{column}) != #{root.inspect}
+          ancestor_ids.present?
         end
         alias has_parent? ancestors?
 
@@ -69,16 +68,15 @@ module Ancestry
         end
 
         def parent_id_in_database
-          #{format_module}.#{parse_method}(attribute_in_database(:#{column})).last
+          ancestor_ids_in_database.last
         end
 
         def parent_id_before_last_save
-          #{format_module}.#{parse_method}(attribute_before_last_save(:#{column})).last
+          ancestor_ids_before_last_save.last
         end
 
-        # optimization - better to go directly to column and avoid parsing
         def sibling_of?(node)
-          read_attribute(:#{column}) == node.read_attribute(:#{column})
+          ancestor_ids == node.ancestor_ids
         end
 
         def child_ancestry
@@ -332,7 +330,7 @@ module Ancestry
           <<~RUBY
             def ancestry_depth_of_descendants
               return if new_record? || (respond_to?(:previously_new_record?) && previously_new_record?)
-              validate_depth_of_descendants(:#{depth_cache_column}, self.class.ancestry_depth_change(attribute_in_database(:#{column}), read_attribute(:#{column})))
+              validate_depth_of_descendants(:#{depth_cache_column}, ancestor_ids.size - ancestor_ids_in_database.size)
             end
           RUBY
         else

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -82,7 +82,7 @@ module Ancestry
         def child_ancestry
           raise(Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record")) if new_record?
 
-          #{format_module}.child_ancestry_value(attribute_in_database(:#{column}), id)
+          self.class.generate_ancestry(path_ids_in_database)
         end
 
         def child_ancestry_before_last_save
@@ -90,7 +90,7 @@ module Ancestry
             raise Ancestry::AncestryException, I18n.t("ancestry.no_child_for_new_record")
           end
 
-          #{format_module}.child_ancestry_value(attribute_before_last_save(:#{column}), id)
+          self.class.generate_ancestry(path_ids_before_last_save)
         end
 
         def ancestry_changed?

--- a/lib/ancestry/instance_methods_builder.rb
+++ b/lib/ancestry/instance_methods_builder.rb
@@ -45,14 +45,6 @@ module Ancestry
 
         #{ if column.to_s == "ancestor_ids"
         <<~RUBY
-          def ancestry
-            read_attribute(:#{column})&.join("/")
-          end
-
-          def ancestry=(value)
-            write_attribute(:#{column}, value&.split("/") || [])
-          end
-
           def ancestor_ids=(value)
             super
             #{"ancestry_sync_parent_cache(#{parent_cache_column.inspect}, value)" if parent_cache_column || parent_association}

--- a/lib/ancestry/ltree.rb
+++ b/lib/ancestry/ltree.rb
@@ -35,10 +35,6 @@ module Ancestry
       end
     end
 
-    def self.child_ancestry_value(ancestry_value, id)
-      ancestry_value.blank? ? id.to_s : "#{ancestry_value}.#{id}"
-    end
-
     def self.siblings_condition(attr, ancestry_value)
       attr.eq(ancestry_value)
     end

--- a/lib/ancestry/materialized_path.rb
+++ b/lib/ancestry/materialized_path.rb
@@ -37,10 +37,6 @@ module Ancestry
       obj.split(DELIMITER).map!(&:to_i)
     end
 
-    def self.child_ancestry_value(ancestry_value, id)
-      [ancestry_value, id].compact.join(DELIMITER)
-    end
-
     # Arel condition: root nodes have ancestry equal to the root value
     def self.roots_condition(attr)
       attr.eq(root)

--- a/lib/ancestry/materialized_path2.rb
+++ b/lib/ancestry/materialized_path2.rb
@@ -32,11 +32,6 @@ module Ancestry
       end
     end
 
-    # trailing delimiter: /1/2/ + 3 + / → /1/2/3/
-    def self.child_ancestry_value(ancestry_value, id)
-      "#{ancestry_value}#{id}/"
-    end
-
     # trailing delimiter: col || pk || '/'
     def self.child_ancestry_sql(table_name, ancestry_column, primary_key, adapter, integer_pk: true)
       concat(adapter, "#{table_name}.#{ancestry_column}", "#{table_name}.#{primary_key}", "'/'")

--- a/lib/ancestry/materialized_path_array.rb
+++ b/lib/ancestry/materialized_path_array.rb
@@ -24,10 +24,6 @@ module Ancestry
       obj.presence || []
     end
 
-    def self.child_ancestry_value(ancestry_value, id)
-      (ancestry_value.presence || []) + [id]
-    end
-
     # Build ARRAY[...] literal with proper quoting and cast for the given values
     def self.array_literal(values)
       if values.first.is_a?(Integer)

--- a/test/concerns/array_test.rb
+++ b/test/concerns/array_test.rb
@@ -20,13 +20,6 @@ class ArrayTest < ActiveSupport::TestCase
     assert_equal %w[1 2 3], mod.parse([1, 2, 3])
   end
 
-  def test_child_ancestry_value
-    mod = Ancestry::MaterializedPathArray
-    assert_equal [1],       mod.child_ancestry_value([], 1)
-    assert_equal [1, 2],    mod.child_ancestry_value([1], 2)
-    assert_equal [1, 2, 3], mod.child_ancestry_value([1, 2], 3)
-  end
-
   # DB tests — require PostgreSQL (integer[] column type)
 
   def test_ancestry_column_array

--- a/test/concerns/array_test.rb
+++ b/test/concerns/array_test.rb
@@ -25,14 +25,14 @@ class ArrayTest < ActiveSupport::TestCase
   def test_ancestry_column_array
     skip "requires PostgreSQL 7.0+" unless AncestryTestDatabase.postgres? && ActiveRecord::VERSION::STRING >= "7.0"
 
-    AncestryTestDatabase.with_model(ancestry_format: :array) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :array, ancestry_column: :ancestor_ids) do |model|
       root = model.create!
       child = model.create!(parent: root)
       grand = model.create!(parent: child)
 
-      assert_equal [],                root.read_attribute(AncestryTestDatabase.ancestry_column)
-      assert_equal [root.id],         child.read_attribute(AncestryTestDatabase.ancestry_column)
-      assert_equal [root.id, child.id], grand.read_attribute(AncestryTestDatabase.ancestry_column)
+      assert_equal [],                  root.read_attribute(:ancestor_ids)
+      assert_equal [root.id],           child.read_attribute(:ancestor_ids)
+      assert_equal [root.id, child.id], grand.read_attribute(:ancestor_ids)
 
       assert_equal [root.id, child.id], grand.ancestor_ids
       assert_equal child.id, grand.parent_id
@@ -43,7 +43,7 @@ class ArrayTest < ActiveSupport::TestCase
   def test_update_strategy_sql
     skip "requires PostgreSQL 7.0+" unless AncestryTestDatabase.postgres? && ActiveRecord::VERSION::STRING >= "7.0"
 
-    AncestryTestDatabase.with_model(ancestry_format: :array, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :array, ancestry_column: :ancestor_ids, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
       node = model.at_depth(1).first
       root = model.roots.first
       new_root = model.create!
@@ -62,7 +62,7 @@ class ArrayTest < ActiveSupport::TestCase
   def test_move_root_to_child_and_back_sql
     skip "requires PostgreSQL 7.0+" unless AncestryTestDatabase.postgres? && ActiveRecord::VERSION::STRING >= "7.0"
 
-    AncestryTestDatabase.with_model(ancestry_format: :array, depth: 2, width: 2, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :array, ancestry_column: :ancestor_ids, depth: 2, width: 2, update_strategy: :sql) do |model, _roots|
       root = model.roots.first
       other_root = model.roots.last
       child = root.children.first
@@ -83,7 +83,7 @@ class ArrayTest < ActiveSupport::TestCase
   def test_ancestry_validation_exclude_self
     skip "requires PostgreSQL 7.0+" unless AncestryTestDatabase.postgres? && ActiveRecord::VERSION::STRING >= "7.0"
 
-    AncestryTestDatabase.with_model(ancestry_format: :array) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :array, ancestry_column: :ancestor_ids) do |model|
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do
@@ -97,7 +97,7 @@ class ArrayTest < ActiveSupport::TestCase
   def test_reparent_across_trees
     skip "requires PostgreSQL 7.0+" unless AncestryTestDatabase.postgres? && ActiveRecord::VERSION::STRING >= "7.0"
 
-    AncestryTestDatabase.with_model(ancestry_format: :array, depth: 3, width: 3) do |model, roots|
+    AncestryTestDatabase.with_model(ancestry_format: :array, ancestry_column: :ancestor_ids, depth: 3, width: 3) do |model, roots|
       root1, root2, root3 = roots.map(&:first)
 
       root1.update!(parent: root2)

--- a/test/concerns/integrity_checking_and_restoration_test.rb
+++ b/test/concerns/integrity_checking_and_restoration_test.rb
@@ -46,7 +46,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
     AncestryTestDatabase.with_model do |model|
       # Check detection of conflicting parent id
       model.destroy_all
-      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => nil).id]).id])
+      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => []).id]).id])
       assert_raise Ancestry::AncestryIntegrityException do
         model.check_ancestry_integrity!
       end
@@ -107,7 +107,7 @@ class IntegrityCheckingAndRestaurationTest < ActiveSupport::TestCase
     # Check that integrity is restored for conflicting parent id
     AncestryTestDatabase.with_model do |model|
       model.destroy_all
-      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => nil).id]).id])
+      model.create!(:ancestor_ids => [model.create!(:ancestor_ids => [model.create!(:ancestor_ids => []).id]).id])
       assert_integrity_restoration model
     end
   end

--- a/test/concerns/ltree_test.rb
+++ b/test/concerns/ltree_test.rb
@@ -25,40 +25,46 @@ class LtreeTest < ActiveSupport::TestCase
   def test_ancestry_column_ltree
     skip "requires PostgreSQL" unless AncestryTestDatabase.postgres?
 
-    AncestryTestDatabase.with_model(ancestry_format: :ltree) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :ltree, ancestry_column: :tree_path) do |model|
       root = model.create!
       node = model.new
 
       # new node (default is "" not nil since ltree column has default)
-      assert_ancestry node, ""
+      assert_equal "", node.tree_path
       assert_raises(Ancestry::AncestryException) { node.child_ancestry }
 
       # saved
       node.save!
-      assert_ancestry node, "", child: node.id.to_s
+      assert_equal "", node.tree_path
+      assert_equal node.id.to_s, node.child_ancestry
 
       # changed
       node.ancestor_ids = [root.id]
-      assert_ancestry node, root.id.to_s, db: "", child: node.id.to_s
+      assert_equal root.id.to_s, node.tree_path
+      assert_equal "", node.tree_path_in_database
+      assert_equal node.id.to_s, node.child_ancestry
 
       # changed saved
       node.save!
-      assert_ancestry node, root.id.to_s, child: "#{root.id}.#{node.id}"
+      assert_equal root.id.to_s, node.tree_path
+      assert_equal "#{root.id}.#{node.id}", node.child_ancestry
 
       # reloaded
       node.reload
-      assert_ancestry node, root.id.to_s, child: "#{root.id}.#{node.id}"
+      assert_equal root.id.to_s, node.tree_path
+      assert_equal "#{root.id}.#{node.id}", node.child_ancestry
 
       # fresh node
       node = model.find(node.id)
-      assert_ancestry node, root.id.to_s, child: "#{root.id}.#{node.id}"
+      assert_equal root.id.to_s, node.tree_path
+      assert_equal "#{root.id}.#{node.id}", node.child_ancestry
     end
   end
 
   def test_update_strategy_sql
     skip "requires PostgreSQL" unless AncestryTestDatabase.postgres?
 
-    AncestryTestDatabase.with_model(ancestry_format: :ltree, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :ltree, ancestry_column: :tree_path, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
       node = model.at_depth(1).first
       root = model.roots.first
       new_root = model.create!
@@ -77,7 +83,7 @@ class LtreeTest < ActiveSupport::TestCase
   def test_move_root_to_child_and_back_sql
     skip "requires PostgreSQL" unless AncestryTestDatabase.postgres?
 
-    AncestryTestDatabase.with_model(ancestry_format: :ltree, depth: 2, width: 2, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :ltree, ancestry_column: :tree_path, depth: 2, width: 2, update_strategy: :sql) do |model, _roots|
       root = model.roots.first
       other_root = model.roots.last
       child = root.children.first
@@ -98,7 +104,7 @@ class LtreeTest < ActiveSupport::TestCase
   def test_ancestry_validation_exclude_self
     skip "requires PostgreSQL" unless AncestryTestDatabase.postgres?
 
-    AncestryTestDatabase.with_model(ancestry_format: :ltree) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :ltree, ancestry_column: :tree_path) do |model|
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do

--- a/test/concerns/ltree_test.rb
+++ b/test/concerns/ltree_test.rb
@@ -20,13 +20,6 @@ class LtreeTest < ActiveSupport::TestCase
     assert_equal %w[a b c], mod.parse("a.b.c")
   end
 
-  def test_child_ancestry_value
-    mod = Ancestry::Ltree
-    assert_equal "1",     mod.child_ancestry_value("", 1)
-    assert_equal "1.2",   mod.child_ancestry_value("1", 2)
-    assert_equal "1.2.3", mod.child_ancestry_value("1.2", 3)
-  end
-
   # DB tests — require PostgreSQL with ltree extension
 
   def test_ancestry_column_ltree

--- a/test/concerns/materialized_path2_test.rb
+++ b/test/concerns/materialized_path2_test.rb
@@ -4,41 +4,47 @@ require_relative '../environment'
 
 class MaterializedPath2Test < ActiveSupport::TestCase
   def test_ancestry_column_mp2
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
       root = model.create!
       node = model.new
 
       # new node
-      assert_ancestry node, "/", db: nil
+      assert_equal "/", node.pedigree
       assert_raises(Ancestry::AncestryException) { node.child_ancestry }
 
       # saved
       node.save!
-      assert_ancestry node, "/", child: "/#{node.id}/"
+      assert_equal "/", node.pedigree
+      assert_equal "/#{node.id}/", node.child_ancestry
 
       # changed
       node.ancestor_ids = [root.id]
-      assert_ancestry node, "/#{root.id}/", db: "/", child: "/#{node.id}/"
+      assert_equal "/#{root.id}/", node.pedigree
+      assert_equal "/", node.pedigree_in_database
+      assert_equal "/#{node.id}/", node.child_ancestry
 
       # changed saved
       node.save!
-      assert_ancestry node, "/#{root.id}/", child: "/#{root.id}/#{node.id}/"
+      assert_equal "/#{root.id}/", node.pedigree
+      assert_equal "/#{root.id}/#{node.id}/", node.child_ancestry
 
       # reloaded
       node.reload
-      assert_ancestry node, "/#{root.id}/", child: "/#{root.id}/#{node.id}/"
+      assert_equal "/#{root.id}/", node.pedigree
+      assert_equal "/#{root.id}/#{node.id}/", node.child_ancestry
 
       # fresh node
       node = model.find(node.id)
-      assert_ancestry node, "/#{root.id}/", child: "/#{root.id}/#{node.id}/"
+      assert_equal "/#{root.id}/", node.pedigree
+      assert_equal "/#{root.id}/#{node.id}/", node.child_ancestry
     end
   end
 
   def test_ancestry_column_validation
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2) do |model|
-      node = model.create # assuming id == 1
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
+      node = model.create
       ['/3/', '/10/2/', '/9/4/30/', '/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :pedigree, value
         assert node.sane_ancestor_ids?
         assert node.valid?
       end
@@ -46,10 +52,10 @@ class MaterializedPath2Test < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_fails
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
       node = model.create
       ['/a/', '/a/b/', '/-34/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :pedigree, value
         refute node.sane_ancestor_ids?
         refute node.valid?
       end
@@ -57,27 +63,27 @@ class MaterializedPath2Test < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_string_key
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path2) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
       node = model.create(:id => 'z')
       ['/a/', '/a/b/', '/a/b/c/', '/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :pedigree, value
         assert node.valid?
       end
     end
   end
 
   def test_ancestry_column_validation_string_key_fails
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path2) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
       node = model.create(:id => 'z')
       ['/1/', '/1/2/', '/a-b/c/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :pedigree, value
         refute node.valid?
       end
     end
   end
 
   def test_ancestry_validation_exclude_self
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, ancestry_column: :pedigree) do |model|
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do
@@ -89,7 +95,7 @@ class MaterializedPath2Test < ActiveSupport::TestCase
   end
 
   def test_update_strategy_sql
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path2, ancestry_column: :pedigree, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
       node = model.at_depth(1).first
       root = model.roots.first
       new_root = model.create!

--- a/test/concerns/materialized_path3_test.rb
+++ b/test/concerns/materialized_path3_test.rb
@@ -4,41 +4,47 @@ require_relative '../environment'
 
 class MaterializedPath3Test < ActiveSupport::TestCase
   def test_ancestry_column_mp3
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
       root = model.create!
       node = model.new
 
       # new node
-      assert_ancestry node, "", db: nil
+      assert_equal "", node.bloodline
       assert_raises(Ancestry::AncestryException) { node.child_ancestry }
 
       # saved
       node.save!
-      assert_ancestry node, "", child: "#{node.id}/"
+      assert_equal "", node.bloodline
+      assert_equal "#{node.id}/", node.child_ancestry
 
       # changed
       node.ancestor_ids = [root.id]
-      assert_ancestry node, "#{root.id}/", db: "", child: "#{node.id}/"
+      assert_equal "#{root.id}/", node.bloodline
+      assert_equal "", node.bloodline_in_database
+      assert_equal "#{node.id}/", node.child_ancestry
 
       # changed saved
       node.save!
-      assert_ancestry node, "#{root.id}/", child: "#{root.id}/#{node.id}/"
+      assert_equal "#{root.id}/", node.bloodline
+      assert_equal "#{root.id}/#{node.id}/", node.child_ancestry
 
       # reloaded
       node.reload
-      assert_ancestry node, "#{root.id}/", child: "#{root.id}/#{node.id}/"
+      assert_equal "#{root.id}/", node.bloodline
+      assert_equal "#{root.id}/#{node.id}/", node.child_ancestry
 
       # fresh node
       node = model.find(node.id)
-      assert_ancestry node, "#{root.id}/", child: "#{root.id}/#{node.id}/"
+      assert_equal "#{root.id}/", node.bloodline
+      assert_equal "#{root.id}/#{node.id}/", node.child_ancestry
     end
   end
 
   def test_ancestry_column_validation
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3) do |model|
-      node = model.create # assuming id == 1
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
+      node = model.create
       ['3/', '10/2/', '9/4/30/', ''].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :bloodline, value
         assert node.sane_ancestor_ids?
         assert node.valid?
       end
@@ -46,10 +52,10 @@ class MaterializedPath3Test < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_fails
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
       node = model.create
       ['a/', 'a/b/', '-34/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :bloodline, value
         refute node.sane_ancestor_ids?
         refute node.valid?
       end
@@ -57,27 +63,27 @@ class MaterializedPath3Test < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_string_key
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path3) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
       node = model.create(:id => 'z')
       ['a/', 'a/b/', 'a/b/c/', ''].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :bloodline, value
         assert node.valid?
       end
     end
   end
 
   def test_ancestry_column_validation_string_key_fails
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path3) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
       node = model.create(:id => 'z')
       ['1/', '1/2/', 'a-b/c/'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :bloodline, value
         refute node.valid?
       end
     end
   end
 
   def test_ancestry_validation_exclude_self
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, ancestry_column: :bloodline) do |model|
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do
@@ -89,7 +95,7 @@ class MaterializedPath3Test < ActiveSupport::TestCase
   end
 
   def test_update_strategy_sql
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path3, ancestry_column: :bloodline, depth: 3, width: 1, update_strategy: :sql) do |model, _roots|
       node = model.at_depth(1).first
       root = model.roots.first
       new_root = model.create!

--- a/test/concerns/materialized_path_test.rb
+++ b/test/concerns/materialized_path_test.rb
@@ -4,41 +4,47 @@ require_relative '../environment'
 
 class MaterializedPathTest < ActiveSupport::TestCase
   def test_ancestry_column_values
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
       root = model.create!
       node = model.new
 
       # new node
-      assert_ancestry node, nil
+      assert_nil node.lineage
       assert_raises(Ancestry::AncestryException) { node.child_ancestry }
 
       # saved
       node.save!
-      assert_ancestry node, nil, child: node.id.to_s
+      assert_nil node.lineage
+      assert_equal node.id.to_s, node.child_ancestry
 
       # changed
       node.ancestor_ids = [root.id]
-      assert_ancestry node, root.id.to_s, db: nil, child: node.id.to_s
+      assert_equal root.id.to_s, node.lineage
+      assert_nil node.lineage_in_database
+      assert_equal node.id.to_s, node.child_ancestry
 
       # changed saved
       node.save!
-      assert_ancestry node, root.id.to_s, child: "#{root.id}/#{node.id}"
+      assert_equal root.id.to_s, node.lineage
+      assert_equal "#{root.id}/#{node.id}", node.child_ancestry
 
       # reloaded
       node.reload
-      assert_ancestry node, root.id.to_s, child: "#{root.id}/#{node.id}"
+      assert_equal root.id.to_s, node.lineage
+      assert_equal "#{root.id}/#{node.id}", node.child_ancestry
 
       # fresh node
       node = model.find(node.id)
-      assert_ancestry node, root.id.to_s, child: "#{root.id}/#{node.id}"
+      assert_equal root.id.to_s, node.lineage
+      assert_equal "#{root.id}/#{node.id}", node.child_ancestry
     end
   end
 
   def test_ancestry_column_validation
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path) do |model|
-      node = model.create # assuming id == 1
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
+      node = model.create
       ['3', '10/2', '9/4/30', nil].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :lineage, value
         assert node.sane_ancestor_ids?
         assert node.valid?
       end
@@ -46,10 +52,10 @@ class MaterializedPathTest < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_fails
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
       node = model.create
       ['a', 'a/b', '-34'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :lineage, value
         refute node.sane_ancestor_ids?
         refute node.valid?
       end
@@ -57,10 +63,10 @@ class MaterializedPathTest < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_string_key
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
       node = model.create(:id => 'z')
       ['a', 'a/b', 'a/b/c', nil].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :lineage, value
         assert node.sane_ancestor_ids?
         assert node.valid?
       end
@@ -68,10 +74,10 @@ class MaterializedPathTest < ActiveSupport::TestCase
   end
 
   def test_ancestry_column_validation_string_key_fails
-    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path) do |model|
+    AncestryTestDatabase.with_model(:id => :string, :primary_key_format => /[a-z]/, ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
       node = model.create(:id => 'z')
       ['1', '1/2', 'a-b/c'].each do |value|
-        node.send :write_attribute, AncestryTestDatabase.ancestry_column, value
+        node.send :write_attribute, :lineage, value
         refute node.sane_ancestor_ids?
         refute node.valid?
       end
@@ -79,7 +85,7 @@ class MaterializedPathTest < ActiveSupport::TestCase
   end
 
   def test_ancestry_validation_exclude_self
-    AncestryTestDatabase.with_model(ancestry_format: :materialized_path) do |model|
+    AncestryTestDatabase.with_model(ancestry_format: :materialized_path, ancestry_column: :lineage) do |model|
       parent = model.create!
       child = parent.children.create!
       assert_raise ActiveRecord::RecordInvalid do


### PR DESCRIPTION
Description
===========

Prerequisite for the serializer: internal methods now work with
`ancestor_ids` (array) instead of the raw column string. Only the
parse/generate boundary knows about the format.

Before
------

Builder methods accessed the raw column directly and parsed inline.
Each method carried format knowledge (root literal, delimiter parsing).
Array format went through the same parse/generate path as strings.

After
-----

Internal methods delegate to `ancestor_ids` boundary methods.
`child_ancestry_value` removed from format modules (only caller was
`child_ancestry`, which now uses `generate_ancestry(path_ids)`).
Array format with `ancestor_ids` column skips parse/generate entirely.

What this does NOT do
---------------------

- No serializer (Rails Type) yet
- No validator changes
- No public API changes
- No changes to SQL generation or scopes

Non-obvious changes for developers
-----------------------------------

- Array format now expects `ancestor_ids` as the column name.
- `child_ancestry_value` is gone from format modules. Custom format
  subclasses should implement `generate` instead.
- `@_ancestor_ids` ivar cache bypassed for array format. Goes away
  when serializer lands.

Type of Change
--------------

- [x] Feature

Checklist
---------

- [x] My code follows the style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally

How Has This Been Tested
------------------------

- `bundle exec rake test` (mp1 sqlite)
- `FORMAT=materialized_path2 bundle exec rake test`
- `FORMAT=materialized_path3 bundle exec rake test`
- `FORMAT=array DB=pg bundle exec rake test`
- `ANCESTRY_COLUMN=family_tree bundle exec rake test`