### PR TITLE
Docs: restore generated-column links and add version-tag note

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -5,6 +5,11 @@ Full reference for `has_ancestry` options, global defaults, and advanced setup.
 For getting started, see the [README](README.md).
 For upgrading between versions, see [Upgrading](docs/UPGRADING.md).
 
+> **Reading these docs on GitHub?** The `master` branch reflects bleeding-edge
+> development and may describe features not yet released. Use the branch
+> selector above to switch to the [tag](https://github.com/stefankroes/ancestry/tags)
+> matching the version of the gem you have installed.
+
 ## Table of Contents
 
 - [Ancestry Formats](#ancestry-formats)
@@ -77,12 +82,20 @@ klass = YourModel
 klass.where.not(ancestry: '/').update_all("ancestry = SUBSTRING(ancestry, 2)")
 # Convert root nodes: "/" → ""
 klass.where(ancestry: '/').update_all("ancestry = ''")
+```
 
 ## Cached Columns
 
 Ancestry derives `parent_id`, `root_id`, and `depth` by parsing the ancestry
 column. These options store those values in real database columns for queries,
 joins, and indexing.
+
+Each of the options below also accepts `:virtual` to use a database generated
+column instead of callbacks. Generated columns are defined in your migration
+and computed automatically by the database from the ancestry column — no
+rebuild step is needed. See your database's docs for details:
+[MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-generated-columns.html),
+[PostgreSQL](https://www.postgresql.org/docs/current/ddl-generated-columns.html).
 
 ### Depth Cache
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Ancestry
 
+> **Reading these docs on GitHub?** The `master` branch reflects bleeding-edge
+> development and may describe features not yet released. Use the branch
+> selector above to switch to the [tag](https://github.com/stefankroes/ancestry/tags)
+> matching the version of the gem you have installed.
+
 ## Overview
 
 Ancestry is a gem that allows rails ActiveRecord models to be organized as


### PR DESCRIPTION
## Summary

- The split of `CONFIGURATION.md` out of `README.md` in d8e65f2 dropped the link to MySQL's generated columns docs from the **Cached Columns** section and left the preceding code fence unclosed (the migration block at the end of "Migrating Between Formats" was never closed, so the `## Cached Columns` heading was being absorbed into a code block on GitHub's renderer). This PR restores the MySQL link, adds the equivalent [PostgreSQL generated columns](https://www.postgresql.org/docs/current/ddl-generated-columns.html) link, and closes the fence.
- Adds a note at the top of `README.md` and `CONFIGURATION.md` reminding readers that GitHub's default view is the `master` branch, which tracks active development. They should switch to the [tag](https://github.com/stefankroes/ancestry/tags) matching their installed gem version when consulting these docs — otherwise the docs may describe options or behavior that haven't shipped yet.

## Test plan

- [x] Verified the broken code fence is fixed (the `## Cached Columns` heading now renders as a heading, not code).
- [x] Confirmed both new links resolve (MySQL 8.0 generated columns, PostgreSQL current generated columns).
- [x] Re-rendered both files locally to check the blockquote note renders correctly above the existing content.