### PR TITLE
Add rake check_no_db_at_load task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,21 @@ namespace :db do
   end
 end
 
+desc "Verify lib/ancestry loads without touching the database"
+task :check_no_db_at_load do
+  require "active_record"
+
+  ActiveRecord::Base.singleton_class.prepend(Module.new do
+    def connection(*)
+      raise "DB connection accessed at load time:\n  " +
+            caller.reject { |l| l.include?("active_record/") }.first(5).join("\n  ")
+    end
+  end)
+
+  require "ancestry"
+  puts "OK: lib/ancestry loaded without DB access"
+end
+
 desc "Show uncovered lines from coverage results"
 task :coverage do
   require 'json'


### PR DESCRIPTION
## Description

  Add a rake task that verifies `require "ancestry"` does not trigger a database connection.

  ### Motivation

  Schema-touching regressions at class load time can slip in undetected. No automated check existed to catch
  them.

  ### After

  `rake check_no_db_at_load` requires ancestry and fails if any code triggers a database connection during
  load.

  ## Type of Change
  - [x] Feature

  ## Checklist
  - [x] My code follows the style guidelines (e.g., RuboCop)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally (`bundle exec rake test`)

  ## How Has This Been Tested?

  Ran `rake check_no_db_at_load` locally, confirms ancestry loads without DB access.